### PR TITLE
Fix #73: Handle the case where uploadargs isn't provided

### DIFF
--- a/PORTAL/jobs/__main__.py
+++ b/PORTAL/jobs/__main__.py
@@ -707,7 +707,7 @@ def _add_request_cli(add_cmd, add_hidden=True):
         elif type(args.after) is not tuple:
             raise NotImplementedError(args.after)
         # Handle --upload-arg.
-        uploadargs = ns.pop('uploadargs')
+        uploadargs = ns.pop('uploadargs', None)
         if uploadargs:
             if 'upload' not in args.after:
                 parser.error('--upload-arg requires --upload')


### PR DESCRIPTION
This fixes #73, and looks like this is just an oversight from a recent refactoring for cronjob support.  But @ericsnowcurrently maybe you can confirm if this is sufficient.