### PR TITLE
Support the Mac worker machine

### DIFF
--- a/PORTAL/jobs/__main__.py
+++ b/PORTAL/jobs/__main__.py
@@ -846,6 +846,10 @@ def parse_args(argv=sys.argv[1:], prog=sys.argv[0]):
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument('-v', '--verbose', action='count', default=0)
     common.add_argument('-q', '--quiet', action='count', default=0)
+    common.add_argument(
+        '--worker', default='linux',
+        help='The name of the worker machine to use. (Default: linux)'
+    )
     if add_hidden:
         common.add_argument('--config', dest='cfgfile', metavar='FILE',
                             help='(default: ~benchmarking/BENCH/jobs.json))')
@@ -1015,7 +1019,8 @@ def main(cmd, cmd_kwargs, cfgfile=None, user=None, devmode=False):
     logger.debug('# loading config from %s', cfgfile)
     cfg = JobsConfig.load(cfgfile)
 
-    jobs = Jobs(cfg, devmode=devmode)
+    jobs = Jobs(cmd_kwargs['worker'], cfg, devmode=devmode)
+    cmd_kwargs.pop('worker')
 
     if cmd != 'queue-info' and not cmd.startswith('internal-'):
         # In some cases the mechanism to run jobs from the queue may

--- a/PORTAL/jobs/_common.py
+++ b/PORTAL/jobs/_common.py
@@ -220,7 +220,7 @@ class JobsFS(_utils.FSTree):
 
     @classmethod
     def from_user(cls, user):
-        return cls(f'/home/{user}/BENCH')
+        return cls(f'~{user}/BENCH')
 
     @classmethod
     def from_raw(cls, raw):
@@ -235,7 +235,7 @@ class JobsFS(_utils.FSTree):
         else:
             raise TypeError(raw)
 
-    def __init__(self, root='~/BENCH'):
+    def __init__(self, root=None):
         if not root:
             root = '~/BENCH'
         super().__init__(root)

--- a/PORTAL/jobs/_job.py
+++ b/PORTAL/jobs/_job.py
@@ -200,8 +200,8 @@ class Job:
             user = '$user'
         else:
             user = _utils.check_shell_str(self._cfg.local_user)
-            _utils.check_shell_str(self._cfg.ssh.user)
-            _utils.check_shell_str(self._cfg.ssh.host)
+            _utils.check_shell_str(self._worker.ssh.user)
+            _utils.check_shell_str(self._worker.ssh.host)
             ssh = self._worker.ssh.shell_commands
 
         queue_log = _utils.quote_shell_str(queue_log)
@@ -236,7 +236,7 @@ class Job:
             pvalue = _utils.quote_shell_str(pvalue)
             bvalue = bfiles.look_up(area, name)
             _utils.check_shell_str(bvalue)
-            pushfiles.append((bvalue, pvalue))
+            pushfiles.append((pvalue, bvalue))
         pushfiles = (ssh.push(s, t) for s, t in pushfiles)
         pushfiles = '\n                '.join(pushfiles)
 
@@ -334,7 +334,7 @@ class Job:
         '''[1:-1])
 
     def _get_ssh_agent(self):
-        agent = self._cfg.worker.ssh.agent
+        agent = self.worker.ssh.agent
         if not agent or not agent.check():
             agent = _utils.SSHAgentInfo.find_latest()
             if not agent:

--- a/PORTAL/jobs/_job_compile_bench.py
+++ b/PORTAL/jobs/_job_compile_bench.py
@@ -39,7 +39,7 @@ class CompileBenchRequest(Request):
     PYSTON_BENCHMARKS = _utils.GitHubTarget.from_origin('pyston', 'python-macrobenchmarks')
 
     #pyperformance = PYPERFORMANCE.copy('034f58b')  # 1.0.4 release (2022-01-26)
-    pyperformance = PYPERFORMANCE.copy('5b6142e')  # will be 1.0.5 release
+    pyperformance = PYPERFORMANCE.copy('684eafe')  # will be 1.0.6 release
     pyston_benchmarks = PYSTON_BENCHMARKS.copy('96e7bb3')  # main from 2022-01-21
     #pyperformance = PYPERFORMANCE.fork('ericsnowcurrently', 'python-performance', 'benchmark-management')
     #pyston_benchmarks = PYSTON_BENCHMARKS.fork('ericsnowcurrently', 'pyston-macrobenchmarks', 'pyperformance')
@@ -326,9 +326,12 @@ def build_compile_script(req, bfiles, fake=None):
     maybe_branch = branch or ''
     ref = _utils.check_shell_str(req.pyperformance_ref)
 
-    cpython_repo = _utils.quote_shell_str(bfiles.repos.cpython)
-    pyperformance_repo = _utils.quote_shell_str(bfiles.repos.pyperformance)
-    pyston_benchmarks_repo = _utils.quote_shell_str(bfiles.repos.pyston_benchmarks)
+    cpython_repo = bfiles.repos.cpython
+    pyperformance_repo = bfiles.repos.pyperformance
+    pyston_benchmarks_repo = bfiles.repos.pyston_benchmarks
+    _utils.check_shell_str(cpython_repo, allowspaces=False)
+    _utils.check_shell_str(pyperformance_repo, allowspaces=False)
+    _utils.check_shell_str(pyston_benchmarks_repo, allowspaces=False)
 
     bfiles = bfiles.resolve_request(req.id)
     _utils.check_shell_str(bfiles.work.pidfile)

--- a/PORTAL/jobs/_utils.py
+++ b/PORTAL/jobs/_utils.py
@@ -945,8 +945,6 @@ class FSTree(types.SimpleNamespace):
     def __init__(self, root):
         if not root or root == '.':
             root = CWD
-        else:
-            root = os.path.abspath(os.path.expanduser(root))
         super().__init__(root=root)
 
     def __str__(self):
@@ -3568,14 +3566,15 @@ class SSHCommands:
 
     @classmethod
     def from_config(cls, cfg, **kwargs):
-        return cls(cfg.user, cfg.host, cfg.port, **kwargs)
+        return cls(cfg.user, cfg.host, cfg.port, cfg.agent, **kwargs)
 
-    def __init__(self, user, host, port, *, ssh=None, scp=None):
+    def __init__(self, user, host, port, agent, *, ssh=None, scp=None):
         self.user = check_shell_str(user)
         self.host = check_shell_str(host)
         self.port = int(port)
         if self.port < 1:
             raise ValueError(f'invalid port {self.port}')
+        self.agent = agent
 
         opts = []
         if self.host == 'localhost':
@@ -3601,7 +3600,7 @@ class SSHCommands:
 
     def run_shell(self, cmd, *, agent=None):
         conn = f'{self.user}@{self.host}'
-        return [self._ssh, *self._ssh_opts, conn, *shlex.split(cmd)]
+        return [self._ssh, *self._ssh_opts, conn, cmd]
 
     def push(self, source, target, *, agent=None):
         conn = f'{self.user}@{self.host}'
@@ -3624,7 +3623,7 @@ class SSHShellCommands(SSHCommands):
         return ' '.join(shlex.quote(a) for a in super().run(cmd, *args))
 
     def run_shell(self, cmd, *, agent=None):
-        return ' '.join(super().run_shell(cmd))
+        return ' '.join(super().run_shell(shlex.quote(cmd)))
 
     def push(self, source, target, *, agent=None):
         return ' '.join(super().push(source, target))
@@ -3650,11 +3649,11 @@ class SSHClient(SSHCommands):
 
     @property
     def commands(self):
-        return SSHCommands(self.user, self.host, self.port)
+        return SSHCommands(self.user, self.host, self.port, self.agent)
 
     @property
     def shell_commands(self):
-        return SSHShellCommands(self.user, self.host, self.port)
+        return SSHShellCommands(self.user, self.host, self.port, self.agent)
 
     def check(self, *, agent=None):
         return (self.run_shell('true', agent=agent).returncode == 0)


### PR DESCRIPTION
This adds a new arg `--worker` to select the worker machine.
It looks up a configuration file from `BENCH/WORKERS/{worker_name}` and
then uses a worker-specific queue in `BENCH/QUEUES/{worker_name}`.

The rest of the changes are related to keeping paths in "tilde-including" form
as long as possible for any paths that might be sent to the worker machine,
since tilde-expansion is different on Linux and Mac.