### PR TITLE
Upgrade the benchmark suites

### DIFF
--- a/PORTAL/jobs/_job_compile_bench.py
+++ b/PORTAL/jobs/_job_compile_bench.py
@@ -39,8 +39,8 @@ class CompileBenchRequest(Request):
     PYSTON_BENCHMARKS = _utils.GitHubTarget.from_origin('pyston', 'python-macrobenchmarks')
 
     #pyperformance = PYPERFORMANCE.copy('034f58b')  # 1.0.4 release (2022-01-26)
-    pyperformance = PYPERFORMANCE.copy('5b6142e')  # will be 1.0.5 release
-    pyston_benchmarks = PYSTON_BENCHMARKS.copy('96e7bb3')  # main from 2022-01-21
+    pyperformance = PYPERFORMANCE.copy('b31928f')  # will be 1.0.6 release
+    pyston_benchmarks = PYSTON_BENCHMARKS.copy('a7f89ec')  # main from 2022-08-17
     #pyperformance = PYPERFORMANCE.fork('ericsnowcurrently', 'python-performance', 'benchmark-management')
     #pyston_benchmarks = PYSTON_BENCHMARKS.fork('ericsnowcurrently', 'pyston-macrobenchmarks', 'pyperformance')
 


### PR DESCRIPTION
Upgrade both of the benchmark suites to get more recent (and recently working) benchmarks.