### PR TITLE
Add type annotations

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -8,7 +8,10 @@ jobs:
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
-      - uses: jpetrucciani/mypy-check@master
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Mypy
+        uses: jpetrucciani/mypy-check@master
         with:
-          path: 'PORTAL/jobs'
+          path: 'PORTAL/jobs/*.py'
           python_version: ${{ matrix.python_version }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 jobs:
   mypy:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,13 @@
+name: mypy
+on: [push, pull_request]
+
+jobs:
+  mypy:
+    strategy:
+      matrix:
+        python_version: ["3.7", "3.8", "3.9", "3.10"]
+    steps:
+      - uses: jpetrucciani/mypy-check@master
+        with:
+          path: 'PORTAL/jobs'
+          python_version: ${{ matrix.python_version }}

--- a/PORTAL/jobs/__init__.py
+++ b/PORTAL/jobs/__init__.py
@@ -3,8 +3,7 @@ import os
 import os.path
 import sys
 from typing import (
-    Any, Callable, Iterable, Iterator, Mapping, Optional, Sequence, Tuple,
-    Type, Union
+    Any, Callable, Iterator, Mapping, Optional, Sequence, Tuple, Type, Union
 )
 
 from . import _utils, _pyperformance, _common, _workers, _job, _current
@@ -37,7 +36,7 @@ class JobsConfig(_utils.TopConfig):
                  local_user: str,
                  worker: Optional[Union[str, _workers.WorkerConfig]],
                  data_dir: Optional[str] = None,
-                 **ignored
+                 **_
                  ):
         if not local_user:
             raise ValueError('missing local_user')
@@ -98,7 +97,7 @@ class Jobs:
     def __str__(self):
         return self._fs.root
 
-    def __eq__(self, other):
+    def __eq__(self, _other):
         raise NotImplementedError
 
     @property
@@ -119,7 +118,7 @@ class Jobs:
         try:
             return self._queue
         except AttributeError:
-            self._queue = _queue.JobQueue.from_fstree(self._fs.queue)
+            self._queue = queue_mod.JobQueue.from_fstree(self._fs.queue)
             return self._queue
 
     def iter_all(self) -> Iterator[_job.Job]:

--- a/PORTAL/jobs/__init__.py
+++ b/PORTAL/jobs/__init__.py
@@ -197,8 +197,8 @@ class Jobs:
             self,
             reqid: RequestID,
             kind_kwargs: Optional[Mapping[str, Any]] = None,
-            pushfsattrs: Optional[_utils.FsAttrsType] = None,
-            pullfsattrs: Optional[_utils.FsAttrsType] = None
+            pushfsattrs: Optional[_common.FsAttrsType] = None,
+            pullfsattrs: Optional[_common.FsAttrsType] = None
     ) -> _job.Job:
         if kind_kwargs is None:
             kind_kwargs = {}

--- a/PORTAL/jobs/__init__.py
+++ b/PORTAL/jobs/__init__.py
@@ -81,10 +81,6 @@ class PortalFS(_utils.FSTree):
     @property
     def currentjob(self) -> str:
         return self.jobs.requests.current
-    
-
-SuiteType = Union[None, str, _utils.Sentinel]
-SuitesType = Any  # This is a recursive iterable of SuiteType
 
 
 class Jobs:
@@ -168,7 +164,7 @@ class Jobs:
     def match_results(
             self,
             specifier: Any,
-            suites: SuitesType = None
+            suites: _pyperformance.SuitesType = None
     ) -> Iterator[_pyperformance.PyperfResultsFile]:
         matched = list(self._store.match(specifier, suites=suites))
         if matched:

--- a/PORTAL/jobs/__init__.py
+++ b/PORTAL/jobs/__init__.py
@@ -36,7 +36,7 @@ class JobsConfig(_utils.TopConfig):
                  local_user: str,
                  worker: Optional[Union[str, _workers.WorkerConfig]],
                  data_dir: Optional[str] = None,
-                 **_
+                 **ignored
                  ):
         if not local_user:
             raise ValueError('missing local_user')

--- a/PORTAL/jobs/__init__.py
+++ b/PORTAL/jobs/__init__.py
@@ -2,10 +2,14 @@ import logging
 import os
 import os.path
 import sys
+from typing import (
+    Any, Callable, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence,
+    Tuple, Type, Union
+)
 
 from . import _utils, _pyperformance, _common, _workers, _job, _current
 from . import queue as _queue
-from .requests import RequestID, Request
+from .requests import RequestID, Request, ToRequestIDType
 
 # top-level exports
 from ._common import JobsError, PKG_ROOT
@@ -30,9 +34,9 @@ class JobsConfig(_utils.TopConfig):
     ]
 
     def __init__(self,
-                 local_user,
-                 worker,
-                 data_dir=None,
+                 local_user: str,
+                 worker: str,
+                 data_dir: Optional[str] = None,
                  **ignored
                  ):
         if not local_user:
@@ -52,13 +56,16 @@ class JobsConfig(_utils.TopConfig):
         )
 
     @property
-    def ssh(self):
+    def ssh(self) -> _utils.SSHConnectionConfig:
         return self.worker.ssh
 
 
 class PortalFS(_utils.FSTree):
 
-    def __init__(self, root='~/BENCH'):
+    def __init__(self, root: Optional[str] = None):
+        if root is None:
+            root = "~/BENCH"
+
         super().__init__(root)
 
         self.jobs = _common.JobsFS(self.root)
@@ -70,20 +77,21 @@ class PortalFS(_utils.FSTree):
         self.queue = _queue.JobQueueFS(self.jobs.requests)
 
     @property
-    def currentjob(self):
+    def currentjob(self) -> str:
         return self.jobs.requests.current
 
 
 class Jobs:
 
-    FS = PortalFS
+    FS: Type[_utils.FSTree] = PortalFS
 
-    def __init__(self, cfg, *, devmode=False):
+    def __init__(self, cfg: JobsConfig, *, devmode: bool = False):
         self._cfg = cfg
         self._devmode = devmode
         self._fs = self.FS(cfg.data_dir)
         self._workers = _workers.Workers.from_config(cfg)
         self._store = _pyperformance.FasterCPythonResults.from_remote()
+        self._queue: Optional[_queue.JobQueue] = None
 
     def __str__(self):
         return self._fs.root
@@ -92,34 +100,32 @@ class Jobs:
         raise NotImplementedError
 
     @property
-    def cfg(self):
+    def cfg(self) -> JobsConfig:
         return self._cfg
 
     @property
-    def devmode(self):
+    def devmode(self) -> bool:
         return self._devmode
 
     @property
-    def fs(self):
+    def fs(self) -> _utils.FSTree:
         """Files on the portal host."""
         return self._fs.jobs.copy()
 
     @property
-    def queue(self):
-        try:
-            return self._queue
-        except AttributeError:
+    def queue(self) -> _queue.JobQueue:
+        if self._queue is None:
             self._queue = _queue.JobQueue.from_fstree(self._fs.queue)
-            return self._queue
+        return self._queue
 
-    def iter_all(self):
+    def iter_all(self) -> Iterator[_job.Job]:
         for name in os.listdir(str(self._fs.jobs.requests)):
             reqid = RequestID.parse(name)
             if not reqid:
                 continue
             yield self._get(reqid)
 
-    def _get(self, reqid):
+    def _get(self, reqid: RequestID) -> _job.Job:
         return _job.Job(
             reqid,
             self._fs.jobs.resolve_request(reqid),
@@ -128,25 +134,24 @@ class Jobs:
             self._store,
         )
 
-    def get_current(self):
+    def get_current(self) -> Optional[_job.Job]:
         reqid = _current.get_staged_request(self._fs.jobs)
         if not reqid:
             return None
         return self._get(reqid)
 
-    def get(self, reqid=None):
+    def get(self, reqid: Optional[ToRequestIDType] = None) -> Optional[_job.Job]:
         if not reqid:
             return self.get_current()
-        orig = reqid
-        reqid = RequestID.from_raw(orig)
-        if not reqid:
-            if isinstance(orig, str):
-                reqid = self._parse_reqdir(orig)
-            if not reqid:
+        reqid_resolved = RequestID.from_raw(reqid)
+        if not reqid_resolved:
+            if isinstance(reqid, str):
+                reqid_resolved = self._parse_reqdir(reqid)
+            if not reqid_resolved:
                 return None
-        return self._get(reqid)
+        return self._get(reqid_resolved)
 
-    def _parse_reqdir(self, filename):
+    def _parse_reqdir(self, filename: str) -> RequestID:
         dirname, basename = os.path.split(filename)
         reqid = RequestID.parse(basename)
         if not reqid:
@@ -154,14 +159,20 @@ class Jobs:
             reqid = RequestID.parse(os.path.basename(dirname))
         return reqid
 
-    def match_results(self, specifier, suites=None):
+    def match_results(
+            self, specifier: Any, suites: Optional[Any] = None
+    ) -> Iterator[Optional[Any]]:
         matched = list(self._store.match(specifier, suites=suites))
         if matched:
             yield from matched
         else:
             yield from self._match_job_results(specifier, suites)
 
-    def _match_job_results(self, specifier, suites):
+    def _match_job_results(
+            self,
+            specifier: Union[str, RequestID],
+            suites: Optional[Any]
+    ) -> Iterator[Optional[Any]]:
         if isinstance(specifier, str):
             job = self.get(specifier)
             if job:
@@ -174,14 +185,20 @@ class Jobs:
                     resultsroot=self._fs.jobs.results.root,
                 )
 
-    def create(self, reqid, kind_kwargs=None, pushfsattrs=None, pullfsattrs=None):
+    def create(
+            self,
+            reqid: RequestID,
+            kind_kwargs: Optional[Mapping[str, Any]] = None,
+            pushfsattrs: Optional[_utils.FsAttrsType] = None,
+            pullfsattrs: Optional[_utils.FsAttrsType] = None
+    ) -> _job.Job:
         if kind_kwargs is None:
             kind_kwargs = {}
         job = self._get(reqid)
         job._create(kind_kwargs, pushfsattrs, pullfsattrs, self._fs.queue.log)
         return job
 
-    def activate(self, reqid):
+    def activate(self, reqid: RequestID) -> _job.Job:
         logger.debug('# staging request')
         _current.stage_request(reqid, self._fs.jobs)
         logger.debug('# done staging request')
@@ -189,53 +206,57 @@ class Jobs:
         job.set_status('activated')
         return job
 
-    def wait_until_job_started(self, job=None, *, timeout=True):
+    def wait_until_job_started(
+            self,
+            job: Optional[Union[_job.Job, RequestID]] = None,
+            *,
+            timeout: bool = True
+    ) -> Tuple[_job.Job, int]:
         current = _current.get_staged_request(self._fs.jobs)
         if isinstance(job, _job.Job):
             reqid = job.reqid
         else:
-            reqid = job
-            if not reqid:
-                reqid = current
-                if not reqid:
+            if not job:
+                if not current:
                     raise NoRunningJobError
+                reqid = current
+            else:
+                reqid = job
             job = self._get(reqid)
         if timeout is True:
             # Calculate the timeout.
             if current:
                 if reqid == current:
-                    timeout = 0
+                    timeout_time = 0
                 else:
                     try:
                         jobkind = _common.resolve_job_kind(reqid.kind)
                     except KeyError:
                         raise NotImplementedError(reqid)
-                    expected = jobkind.TYPICAL_DURATION_SECS
+                    expected = jobkind.TYPICAL_DURATION_SECS or 0
                     # We could subtract the elapsed time, but it isn't worth it.
-                    timeout = expected
-            if timeout:
+                    timeout_time = expected
+            if timeout_time:
                 # Add the expected time for everything in the queue before the job.
-                if timeout is True:
-                    timeout = 0
                 for i, queued in enumerate(self.queue.snapshot):
                     if queued == reqid:
                         # Play it safe by doubling the timeout.
-                        timeout *= 2
+                        timeout_time *= 2
                         break
                     try:
                         jobkind = _common.resolve_job_kind(queued.kind)
                     except KeyError:
                         raise NotImplementedError(queued)
-                    expected = jobkind.TYPICAL_DURATION_SECS
-                    timeout += expected
+                    expected = jobkind.TYPICAL_DURATION_SECS or 0
+                    timeout_time += expected
                 else:
                     # Either it hasn't been queued or it already finished.
-                    timeout = 0
+                    timeout_time = 0
         # Wait!
-        pid = job.wait_until_started(timeout)
+        pid = job.wait_until_started(timeout_time)
         return job, pid
 
-    def ensure_next(self):
+    def ensure_next(self) -> None:
         logger.debug('Making sure a job is running, if possible')
         # XXX Return (queued job, already running job).
         job = self.get_current()
@@ -266,7 +287,12 @@ class Jobs:
             cwd=_common.SYS_PATH_ENTRY,
         )
 
-    def cancel_current(self, reqid=None, *, ifstatus=None):
+    def cancel_current(
+            self,
+            reqid: Optional[RequestID] = None,
+            *,
+            ifstatus: Optional[str] = None
+    ) -> _job.Job:
         job = self.get(reqid)
         if job is None:
             raise NoRunningJobError
@@ -280,7 +306,7 @@ class Jobs:
         logger.info('# done unstaging request')
         return job
 
-    def finish_successful(self, reqid):
+    def finish_successful(self, reqid: RequestID) -> _job.Job:
         logger.info('# unstaging request %s', reqid)
         try:
             _current.unstage_request(reqid, self._fs.jobs)
@@ -293,12 +319,20 @@ class Jobs:
         return job
 
 
-_SORT = {
+_SORT: Mapping[str, Callable[[_job.Job], RequestID]] = {
     'reqid': (lambda j: j.reqid),
 }
 
 
-def sort_jobs(jobs, sortby=None, *, ascending=False):
+ToJobsType = Union[Jobs, Sequence[_job.Job]]
+
+
+def sort_jobs(
+        jobs: ToJobsType,
+        sortby: Optional[Union[str, Sequence[str]]] = None,
+        *,
+        ascending: bool = False
+) -> Sequence[_job.Job]:
     if isinstance(jobs, Jobs):
         jobs = list(jobs.iter_all())
     if not sortby:
@@ -324,7 +358,10 @@ def select_job(jobs, criteria=None):
     raise NotImplementedError
 
 
-def select_jobs(jobs, criteria=None):
+def select_jobs(
+        jobs: ToJobsType,
+        criteria: Optional[Union[str, Sequence[str]]] = None
+) -> Iterator[_job.Job]:
     # CSV
     # ranges (i.e. slice)
     if isinstance(jobs, Jobs):
@@ -333,15 +370,12 @@ def select_jobs(jobs, criteria=None):
         yield from jobs
         return
     if isinstance(criteria, str):
-        criteria = [criteria]
+        criteria_seq = [criteria]
     else:
-        try:
-            criteria = list(criteria)
-        except TypeError:
-            criteria = [criteria]
-    if len(criteria) > 1:
+        criteria_seq = list(criteria)
+    if len(criteria_seq) > 1:
         raise NotImplementedError(criteria)
-    selection = _utils.get_slice(criteria[0])
+    selection = _utils.get_slice(criteria_seq[0])
     if not isinstance(jobs, (list, tuple)):
         jobs = list(jobs)
     yield from jobs[selection]

--- a/PORTAL/jobs/__init__.py
+++ b/PORTAL/jobs/__init__.py
@@ -35,7 +35,7 @@ class JobsConfig(_utils.TopConfig):
 
     def __init__(self,
                  local_user: str,
-                 worker: str,
+                 worker: Optional[Union[str, _workers.WorkerConfig]],
                  data_dir: Optional[str] = None,
                  **ignored
                  ):
@@ -44,14 +44,16 @@ class JobsConfig(_utils.TopConfig):
         if not worker:
             raise ValueError('missing worker')
         elif not isinstance(worker, _workers.WorkerConfig):
-            worker = _workers.WorkerConfig.from_jsonable(worker)
+            worker_resolved = _workers.WorkerConfig.from_jsonable(worker)
+        else:
+            worker_resolved = worker
         if data_dir:
             data_dir = os.path.abspath(os.path.expanduser(data_dir))
         else:
             data_dir = f'/home/{local_user}/BENCH'  # This matches DATA_ROOT.
         super().__init__(
             local_user=local_user,
-            worker=worker,
+            worker=worker_resolved,
             data_dir=data_dir or None,
         )
 

--- a/PORTAL/jobs/__main__.py
+++ b/PORTAL/jobs/__main__.py
@@ -18,7 +18,7 @@ from ._job import (
     Job, JobNeverStartedError, JobAlreadyFinishedError, JobFinishedError,
 )
 from ._current import RequestAlreadyStagedError
-from .requests import RequestID, Result, ToRequestIDType
+from .requests import RequestID, Result
 from .queue import (
     JobQueuePausedError, JobQueueNotPausedError, JobQueueEmptyError,
     JobNotQueuedError, JobAlreadyQueuedError,
@@ -556,7 +556,7 @@ def cmd_queue_move(
         jobs: Jobs,
         reqid: RequestID,
         position: int,
-        relative = None  # TYPE_TODO
+        relative: str = None
 ) -> None:
     position = int(position)
     if position <= 0:

--- a/PORTAL/jobs/__main__.py
+++ b/PORTAL/jobs/__main__.py
@@ -4,6 +4,10 @@ import os
 import os.path
 import sys
 import traceback
+from typing import (
+    Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional,
+    Sequence, Tuple, Union
+)
 
 from . import (
     NoRunningJobError,
@@ -11,7 +15,7 @@ from . import (
     sort_jobs, select_jobs,
 )
 from ._job import (
-    JobNeverStartedError, JobAlreadyFinishedError, JobFinishedError,
+    Job, JobNeverStartedError, JobAlreadyFinishedError, JobFinishedError,
 )
 from ._current import RequestAlreadyStagedError
 from .requests import RequestID, Result
@@ -33,11 +37,15 @@ logger = logging.getLogger(__name__)
 ##################################
 # commands
 
-def cmd_list(jobs, selections=None, columns=None):
+def cmd_list(
+        jobs: Jobs,
+        selections: Optional[Union[str, Sequence[str]]] = None,
+        columns: Optional[str] = None
+) -> None:
 #    requests = (RequestID.parse(n) for n in os.listdir(jobs.fs.requests.root))
     alljobs = list(jobs.iter_all())
     total = len(alljobs)
-    alljobs = sort_jobs(alljobs)
+    alljobs = list(sort_jobs(alljobs))
     selected = list(select_jobs(alljobs, selections))
 
     colspecs = [
@@ -61,23 +69,23 @@ def cmd_list(jobs, selections=None, columns=None):
 
     rows = (j.as_row() for j in selected)
     periodic = [table.div, table.header, table.div]
-    rows = table.render_rows(rows, periodic, len(selected))
+    rendered_rows = table.render_rows(rows, periodic, len(selected))
 
     logger.info('(all times in UTC)')
     logger.info('')
     logger.info(table.div)
     print(table.header)
     print(table.div)
-    for line in rows:
+    for line in rendered_rows:
         print(line)
     logger.info(table.div)
-    for line in rows.render_count(total):
+    for line in rendered_rows.render_count(total):
         logger.info(line)
     logger.info('')
 
     current = jobs.get_current()
-    current = current.reqid if current else 'none'
-    logger.info(f'Currently running: {current}')
+    current_reqid = current.reqid if current else 'none'
+    logger.info(f'Currently running: {current_reqid}')
     logger.info('')
 
     queue = jobs.queue.snapshot
@@ -89,7 +97,13 @@ def cmd_list(jobs, selections=None, columns=None):
     logger.info('')
 
 
-def cmd_show(jobs, reqid=None, fmt=None, *, lines=None):
+def cmd_show(
+        jobs: Jobs,
+        reqid: Optional[RequestID] = None,
+        fmt: Optional[str] = None,
+        *,
+        lines: Optional[Sequence[str]] = None
+) -> None:
     job = jobs.get(reqid)
     if not job:
         # XXX Use the last finished?
@@ -103,14 +117,18 @@ def cmd_show(jobs, reqid=None, fmt=None, *, lines=None):
         tail_file(job.fs.logfile, lines, follow=False)
 
 
-def cmd_request_compile_bench(jobs, reqid, revision, *,
-                              remote=None,
-                              branch=None,
-                              benchmarks=None,
-                              optimize=True,
-                              debug=False,
-                              _fake=None,
-                              ):
+def cmd_request_compile_bench(
+        jobs: Jobs,
+        reqid: Optional[RequestID],
+        revision: str,
+        *,
+        remote: Optional[str] = None,
+        branch: Optional[str] = None,
+        benchmarks: Optional[str] = None,
+        optimize: bool = True,
+        debug: bool = False,
+        _fake: Any = None,
+) -> Job:
     if not reqid:
         raise NotImplementedError
     assert reqid.kind == 'compile-bench', reqid
@@ -134,15 +152,21 @@ def cmd_request_compile_bench(jobs, reqid, revision, *,
     return job
 
 
-def cmd_copy(jobs, reqid=None):
+def cmd_copy(jobs: Jobs, reqid: Optional[RequestID] = None) -> None:
     raise NotImplementedError
 
 
-def cmd_remove(jobs, reqid):
+def cmd_remove(jobs: Jobs, reqid: RequestID):
     raise NotImplementedError
 
 
-def cmd_run(jobs, reqid, *, copy=False, force=False):
+def cmd_run(
+        jobs: Jobs,
+        reqid: RequestID,
+        *,
+        copy: bool = False,
+        force: bool = False
+) -> None:
     if copy:
         raise NotImplementedError
     if force:
@@ -158,7 +182,7 @@ def cmd_run(jobs, reqid, *, copy=False, force=False):
         job.check_ssh(onunknown='wait:3')
 
 
-def _cmd_run(jobs, reqid):
+def _cmd_run(jobs: Jobs, reqid: RequestID) -> Job:
     # Try staging it directly.
     try:
         job = jobs.activate(reqid)
@@ -169,15 +193,21 @@ def _cmd_run(jobs, reqid):
     except Exception:
         logger.error('could not stage request')
         logger.info('')
-        job = jobs.get(reqid)
-        job.set_status('failed')
+        job_lookup = jobs.get(reqid)
+        if job_lookup is not None:
+            job_lookup.set_status('failed')
         raise  # re-raise
     else:
         job.run(background=True)
         return job
 
 
-def cmd_attach(jobs, reqid=None, *, lines=None):
+def cmd_attach(
+        jobs: Jobs,
+        reqid: Optional[RequestID] = None,
+        *,
+        lines: Iterable[str] = None
+) -> None:
     try:
         try:
             job, pid = jobs.wait_until_job_started(reqid)
@@ -196,7 +226,15 @@ def cmd_attach(jobs, reqid=None, *, lines=None):
         pass
 
 
-def cmd_cancel(jobs, reqid=None, *, _status=None):
+def cmd_cancel(
+        jobs: Jobs,
+        reqid: Optional[RequestID] = None,
+        *,
+        _status: Optional[str] = None
+) -> None:
+    job: Optional[Job]
+    current: Optional[Job]
+
     if not reqid:
         try:
             job = current = jobs.cancel_current(ifstatus=_status)
@@ -213,19 +251,24 @@ def cmd_cancel(jobs, reqid=None, *, _status=None):
         else:
             cmd_queue_remove(jobs, reqid)
             job = jobs.get(reqid)
-            job.cancel(ifstatus=_status)
+            if job:
+                job.cancel(ifstatus=_status)
+            else:
+                raise RuntimeError(f"Couldn't get job for {reqid}")
 
     logger.info('')
     logger.info('Results:')
     # XXX Show something better?
-    for line in job.render(fmt='resfile'):
-        logger.info(line)
+
+    if job:
+        for line in job.render(fmt='resfile'):
+            logger.info(line)
 
     if current:
         jobs.ensure_next()
 
 
-def cmd_wait(jobs, reqid=None):
+def cmd_wait(jobs: Jobs, reqid: Optional[RequestID] = None) -> None:
     try:
         try:
             job, pid = jobs.wait_until_job_started(reqid)
@@ -245,12 +288,29 @@ def cmd_wait(jobs, reqid=None):
         pass
 
 
-def cmd_upload(jobs, reqid, *, author=None, clean=True, push=True):
+def cmd_upload(
+        jobs: Jobs,
+        reqid: RequestID,
+        *,
+        author: Optional[str] = None,
+        clean: bool = True,
+        push: bool = True
+) -> None:
     job = jobs.get(reqid)
-    job.upload_result(author, clean=clean, push=push)
+    if job:
+        job.upload_result(author, clean=clean, push=push)
+    else:
+        raise RuntimeError(f"Couldn't get job for {reqid}")
 
 
-def cmd_compare(jobs, res1, others, *, meanonly=False, pyston=False):
+def cmd_compare(
+        jobs: Jobs,
+        res1: Any,
+        others: List[Any],
+        *,
+        meanonly: bool = False,
+        pyston: bool = False
+) -> None:
     suites = ['pyston'] if pyston else ['pyperformance']
     matched = list(jobs.match_results(res1, suites=suites))
     if not matched:
@@ -273,7 +333,7 @@ def cmd_compare(jobs, res1, others, *, meanonly=False, pyston=False):
 
 
 # internal
-def cmd_finish_run(jobs, reqid):
+def cmd_finish_run(jobs: Jobs, reqid: RequestID) -> None:
     job = jobs.finish_successful(reqid)
 
     logger.info('')
@@ -284,7 +344,7 @@ def cmd_finish_run(jobs, reqid):
 
 
 # internal
-def cmd_run_next(jobs):
+def cmd_run_next(jobs: Jobs) -> None:
     logentry = LogSection.from_title('Running next queued job')
     print()
     for line in logentry.render():
@@ -302,7 +362,10 @@ def cmd_run_next(jobs):
     try:
         try:
             job = jobs.get(reqid)
-            status = job.get_status()
+            if job:
+                status = job.get_status()
+            else:
+                raise ValueError("Couldn't get job for {reqid}")
         except Exception:
             logger.error('could not load results metadata')
             logger.warning('%s status could not be updated (to "failed")', reqid)
@@ -330,7 +393,7 @@ def cmd_run_next(jobs):
         logger.info('')
         try:
             _cmd_run(jobs, reqid)
-        except RequestAlreadyStagedError:
+        except RequestAlreadyStagedError as exc:
             if reqid == exc.curid:
                 logger.warn('%s is already running', reqid)
                 # XXX Check the pidfile?
@@ -342,7 +405,7 @@ def cmd_run_next(jobs):
         raise  # re-raise
 
 
-def cmd_queue_info(jobs, *, withlog=True):
+def cmd_queue_info(jobs: Jobs, *, withlog: bool = True) -> None:
     _queue = jobs.queue.snapshot
     queued = _queue.jobs
     paused = _queue.paused
@@ -389,7 +452,7 @@ def cmd_queue_info(jobs, *, withlog=True):
             print('  (log is empty)')
 
 
-def cmd_queue_list(jobs):
+def cmd_queue_list(jobs: Jobs) -> None:
     queue = jobs.queue.snapshot
     if queue.paused:
         logger.warn('job queue is paused')
@@ -405,7 +468,7 @@ def cmd_queue_list(jobs):
     print(f'(total: {i})')
 
 
-def cmd_queue_pause(jobs):
+def cmd_queue_pause(jobs: Jobs) -> None:
     try:
        jobs.queue.pause()
     except JobQueuePausedError:
@@ -414,7 +477,7 @@ def cmd_queue_pause(jobs):
         logger.info('job queue paused')
 
 
-def cmd_queue_unpause(jobs):
+def cmd_queue_unpause(jobs: Jobs) -> None:
     try:
        jobs.queue.unpause()
     except JobQueueNotPausedError:
@@ -424,10 +487,13 @@ def cmd_queue_unpause(jobs):
         jobs.ensure_next()
 
 
-def cmd_queue_push(jobs, reqid):
+def cmd_queue_push(jobs: Jobs, reqid: RequestID) -> None:
     reqid = RequestID.from_raw(reqid)
     logger.info(f'Adding job {reqid} to the queue')
     job = jobs.get(reqid)
+    if not job:
+        logger.error('request %s not found', reqid)
+        sys.exit(1)
 
     status = job.get_status()
     if not status:
@@ -457,7 +523,7 @@ def cmd_queue_push(jobs, reqid):
     jobs.ensure_next()
 
 
-def cmd_queue_pop(jobs):
+def cmd_queue_pop(jobs: Jobs) -> None:
     logger.info(f'Popping the next job from the queue...')
     try:
         reqid = jobs.queue.pop()
@@ -468,6 +534,9 @@ def cmd_queue_pop(jobs):
         logger.error('job queue is empty')
         sys.exit(1)
     job = jobs.get(reqid)
+    if not job:
+        logger.warn('queued request (%s) not found', reqid)
+        return
 
     status = job.get_status()
     if not status:
@@ -482,7 +551,12 @@ def cmd_queue_pop(jobs):
     print(reqid)
 
 
-def cmd_queue_move(jobs, reqid, position, relative=None):
+def cmd_queue_move(
+        jobs: Jobs,
+        reqid: RequestID,
+        position: int,
+        relative = None  # TYPE_TODO
+) -> None:
     position = int(position)
     if position <= 0:
         raise ValueError(f'expected positive position, got {position}')
@@ -495,6 +569,9 @@ def cmd_queue_move(jobs, reqid, position, relative=None):
     else:
         logger.info('Moving job %s to position %s in the queue...', reqid, position)
     job = jobs.get(reqid)
+    if not job:
+        logger.error('request %s not found', reqid)
+        sys.exit(1)
 
     if jobs.queue.paused:
         logger.warn('job queue is paused')
@@ -510,10 +587,13 @@ def cmd_queue_move(jobs, reqid, position, relative=None):
     logger.info('...moved to position %s', pos)
 
 
-def cmd_queue_remove(jobs, reqid):
+def cmd_queue_remove(jobs: Jobs, reqid: RequestID) -> None:
     reqid = RequestID.from_raw(reqid)
     logger.info('Removing job %s from the queue...', reqid)
     job = jobs.get(reqid)
+    if not job:
+        logger.warn('request %s not found', reqid)
+        return
 
     if jobs.queue.paused:
         logger.warn('job queue is paused')
@@ -535,16 +615,16 @@ def cmd_queue_remove(jobs, reqid):
     logger.info('...done!')
 
 
-def cmd_config_show(jobs):
+def cmd_config_show(jobs: Jobs) -> None:
     for line in jobs.cfg.render():
         print(line)
 
 
-def cmd_bench_host_clean(jobs):
+def cmd_bench_host_clean(jobs: Jobs) -> None:
     raise NotImplementedError
 
 
-COMMANDS = {
+COMMANDS: Mapping[str, Callable] = {
     # job management
     'list': cmd_list,
     'show': cmd_show,
@@ -582,9 +662,12 @@ COMMANDS = {
 VERBOSITY = 3
 
 
-def configure_root_logger(verbosity=VERBOSITY, logfile=None, *,
-                          maxlevel=logging.CRITICAL,
-                          ):
+def configure_root_logger(
+        verbosity: int = VERBOSITY,
+        logfile: Optional[str] = None,
+        *,
+        maxlevel: int = logging.CRITICAL,
+) -> None:
     logger = logging.getLogger()
 
     level = max(1,  # 0 disables it, so we use the next lowest.
@@ -594,6 +677,7 @@ def configure_root_logger(verbosity=VERBOSITY, logfile=None, *,
     #logger.propagate = False
 
     assert not logger.handlers, logger.handlers
+    handler: Any
     if logfile:
         handler = logging.FileHandler(logfile)
     else:
@@ -612,10 +696,10 @@ def configure_root_logger(verbosity=VERBOSITY, logfile=None, *,
 
     if not os.isatty(sys.stdout.fileno()):
         global print
-        print = (lambda m='': logger.info(m))
+        print = (lambda m='': logger.info(m))  # type: ignore[name-defined]
 
 
-def _add_request_cli(add_cmd, add_hidden=True):
+def _add_request_cli(add_cmd: Callable, add_hidden: bool = True) -> Callable:
     compile_bench = argparse.ArgumentParser(add_help=False)
     compile_bench.add_argument('--optimize', dest='optimize',
                                action='store_const', const=True, default=True,
@@ -729,7 +813,7 @@ def _add_request_cli(add_cmd, add_hidden=True):
     return handle_args
 
 
-def _add_queue_cli(add_cmd, add_hidden=True):
+def _add_queue_cli(add_cmd: Callable, add_hidden: bool = True) -> Callable:
     if not add_hidden:
         return (lambda *a, **k: None)
 
@@ -800,7 +884,7 @@ def _add_queue_cli(add_cmd, add_hidden=True):
     return handle_args
 
 
-def _add_config_cli(add_cmd, add_hidden=True):
+def _add_config_cli(add_cmd: Callable, add_hidden: bool = True) -> Callable:
     if not add_hidden:
         return (lambda *a, **k: None)
     sub = add_cmd('config', help='Show the config')
@@ -812,7 +896,7 @@ def _add_config_cli(add_cmd, add_hidden=True):
     return handle_args
 
 
-def _add_bench_host_cli(add_cmd, add_hidden=True):
+def _add_bench_host_cli(add_cmd: Callable, add_hidden: bool = True) -> Callable:
     if not add_hidden:
         return (lambda *a, **k: None)
     sub = add_cmd('bench-host', help='Manage the host where benchmarks run')
@@ -827,7 +911,10 @@ def _add_bench_host_cli(add_cmd, add_hidden=True):
     return handle_args
 
 
-def parse_args(argv=sys.argv[1:], prog=sys.argv[0]):
+def parse_args(
+        argv: Sequence[str] = sys.argv[1:],
+        prog: str = sys.argv[0]
+) -> Tuple[str, Dict[str, Any], str, str, int, str, bool]:
 
     ##########
     # Resolve dev mode.
@@ -988,7 +1075,13 @@ def parse_args(argv=sys.argv[1:], prog=sys.argv[0]):
     return cmd, ns, cfgfile, user, verbosity, logfile, devmode
 
 
-def main(cmd, cmd_kwargs, cfgfile=None, user=None, devmode=False):
+def main(
+        cmd: str,
+        cmd_kwargs: MutableMapping[str, Any],
+        cfgfile: Optional[str] = None,
+        user: Optional[str] = None,
+        devmode: bool = False
+) -> None:
     try:
         run_cmd = COMMANDS[cmd]
     except KeyError:
@@ -1056,16 +1149,16 @@ def main(cmd, cmd_kwargs, cfgfile=None, user=None, devmode=False):
             logger.info(line)
 
     # Run "after" commands, if any
-    for cmd, run_cmd, cmd_kwargs in after:
+    for _cmd, _run_cmd, _cmd_kwargs in after:
         logger.info('')
         logger.info('#'*40)
         if reqid:
-            logger.info('# Running %r command for request %s', cmd, reqid)
+            logger.info('# Running %r command for request %s', _cmd, reqid)
         else:
-            logger.info('# Running %r command', cmd)
+            logger.info('# Running %r command', _cmd)
         logger.info('')
         # XXX Add --lines='-1' for attach.
-        run_cmd(jobs, reqid=reqid, **(cmd_kwargs or {}))
+        run_cmd(jobs, reqid=reqid, **(_cmd_kwargs or {}))
 
 
 if __name__ == '__main__':

--- a/PORTAL/jobs/__main__.py
+++ b/PORTAL/jobs/__main__.py
@@ -316,8 +316,8 @@ def cmd_compare(
         sys.exit(1)
     res1_matched, = matched
     others_matched = []
-    for _ in range(len(matched)):
-        spec = matched.pop(0)
+    for _ in range(len(others)):
+        spec = others.pop(0)
         matched = list(jobs.match_results(spec, suites=suites))
         if not matched:
             logger.error(f'no results matched {spec!r}')

--- a/PORTAL/jobs/__main__.py
+++ b/PORTAL/jobs/__main__.py
@@ -314,7 +314,7 @@ def cmd_compare(
     if not matched:
         logger.error(f'no results matched {res1!r}')
         sys.exit(1)
-    res1_results, = matched
+    res1_matched, = matched
     for _ in range(len(others)):
         spec = others.pop(0)
         matched = list(jobs.match_results(spec, suites=suites))
@@ -323,7 +323,7 @@ def cmd_compare(
             sys.exit(1)
         others.extend(matched)
     #others = [*jobs.match_results(r) for r in others]
-    compared = res1_results.compare(others)
+    compared = res1_matched.compare(others)
     if compared is None:
         raise RuntimeError("Could not get comparison")
     table = compared.table

--- a/PORTAL/jobs/__main__.py
+++ b/PORTAL/jobs/__main__.py
@@ -303,8 +303,8 @@ def cmd_upload(
 
 def cmd_compare(
         jobs: Jobs,
-        res1: ToRequestIDType,
-        others: List[Any],
+        res1: str,
+        others: List[str],
         *,
         meanonly: bool = False,
         pyston: bool = False
@@ -315,15 +315,16 @@ def cmd_compare(
         logger.error(f'no results matched {res1!r}')
         sys.exit(1)
     res1_matched, = matched
-    for _ in range(len(others)):
-        spec = others.pop(0)
+    others_matched = []
+    for _ in range(len(matched)):
+        spec = matched.pop(0)
         matched = list(jobs.match_results(spec, suites=suites))
         if not matched:
             logger.error(f'no results matched {spec!r}')
             sys.exit(1)
-        others.extend(matched)
+        others_matched.extend(matched)
     #others = [*jobs.match_results(r) for r in others]
-    compared = res1_matched.compare(others)
+    compared = res1_matched.compare(others_matched)
     if compared is None:
         raise RuntimeError("Could not get comparison")
     table = compared.table

--- a/PORTAL/jobs/_common.py
+++ b/PORTAL/jobs/_common.py
@@ -50,15 +50,23 @@ class JobKind:
 
     def set_request_fs(
             self,
-            fs: _utils.FSTree,
+            fs: "JobRequestFS",
             context: str
     ) -> None:
         raise NotImplementedError
 
-    def set_work_fs(self, fs: _utils.FSTree, context: Optional[str]) -> None:
+    def set_work_fs(
+            self,
+            fs: "JobWorkFS",
+            context: Optional[str]
+    ) -> None:
         raise NotImplementedError
 
-    def set_result_fs(self, fs: _utils.FSTree, context: Optional[str]) -> None:
+    def set_result_fs(
+            self,
+            fs: "JobResultFS",
+            context: Optional[str]
+    ) -> None:
         raise NotImplementedError
 
     def create(
@@ -241,8 +249,6 @@ class JobFS(types.SimpleNamespace):
         return value
 
     def copy(self) -> "JobFS":
-        # XXX This may not work, since it doesn't do a deep copy of the first
-        # three arguments
         return type(self)(
             str(self.request),
             str(self.result),

--- a/PORTAL/jobs/_common.py
+++ b/PORTAL/jobs/_common.py
@@ -1,7 +1,7 @@
 import logging
 import os.path
 import types
-from typing import Any, Optional, Type, Union
+from typing import Any, List, Optional, Tuple, Type, Union
 
 from . import _utils
 from .requests import RequestID, Request, Result, ToRequestIDType
@@ -12,6 +12,10 @@ from . import _workers
 
 PKG_ROOT = os.path.dirname(os.path.abspath(__file__))
 SYS_PATH_ENTRY = os.path.dirname(PKG_ROOT)
+
+
+FsAttrsType = List[Union[Tuple[str, str], str]]
+
 
 logger = logging.getLogger(__name__)
 

--- a/PORTAL/jobs/_common.py
+++ b/PORTAL/jobs/_common.py
@@ -4,7 +4,7 @@ import types
 from typing import Any, List, Optional, Tuple, Type, Union
 
 from . import _utils
-from .requests import RequestID, Request, Result, ToRequestIDType
+from .requests import RequestID, ToRequestIDType
 from . import requests
 from . import _job
 from . import _workers
@@ -280,7 +280,7 @@ class JobsFS(_utils.FSTree):
             cls,
             raw: Optional[Union["JobsFS", str]],
             *,
-            name: Any=None
+            name: Any = None
     ) -> "JobsFS":
         if not raw:
             raise ValueError('missing jobsfs')

--- a/PORTAL/jobs/_common.py
+++ b/PORTAL/jobs/_common.py
@@ -46,8 +46,8 @@ class JobKind:
         'logfile',
     ]
 
-    Request: Type[_utils.Metadata] = Request
-    Result: Type[_utils.Metadata] = Result
+    Request: Type[_utils.Metadata] = requests.Request
+    Result: Type[_utils.Metadata] = requests.Result
 
     #def __new__(cls, *args, **kwargs):
     #    raise TypeError(f'{cls.__name__} instances not supported')

--- a/PORTAL/jobs/_current.py
+++ b/PORTAL/jobs/_current.py
@@ -176,7 +176,8 @@ def unstage_request(
 
 
 def _read_staged(
-        symlink: str, jobsfs: _common.JobsFS
+        symlink: str,
+        jobsfs: _common.JobsFS
 ) -> Optional[RequestID]:
     try:
         reqdir = os.readlink(symlink)

--- a/PORTAL/jobs/_current.py
+++ b/PORTAL/jobs/_current.py
@@ -3,10 +3,10 @@
 import logging
 import os
 import os.path
-from typing import Any, Optional
+from typing import Optional
 
 from . import _utils, _common
-from .requests import RequestID, Result, ToRequestIDType
+from .requests import RequestID, Result
 
 
 logger = logging.getLogger(__name__)
@@ -103,7 +103,7 @@ class RequestNotStagedError(UnstagingRequestError):
         self.curid = curid
 
 
-def symlink_from_jobsfs(jobsfs: Any) -> str:
+def symlink_from_jobsfs(jobsfs: _common.JobsFS) -> str:
     jobsfs = _common.JobsFS.from_raw(jobsfs)
     try:
         return jobsfs.requests.current
@@ -112,7 +112,7 @@ def symlink_from_jobsfs(jobsfs: Any) -> str:
 
 
 def get_staged_request(
-        jobsfs: Any,
+        jobsfs: _common.JobsFS,
         symlink: Optional[str] = None
 ) -> Optional[RequestID]:
     if not symlink:
@@ -133,7 +133,7 @@ def get_staged_request(
 
 
 def stage_request(
-        reqid: ToRequestIDType,
+        reqid: RequestID,
         jobsfs: _common.JobsFS,
         symlink: Optional[str] = None
 ) -> None:
@@ -147,8 +147,8 @@ def stage_request(
 
 
 def unstage_request(
-        reqid: ToRequestIDType,
-        jobsfs: Any,
+        reqid: RequestID,
+        jobsfs: _common.JobsFS,
         symlink: Optional[str] = None
 ) -> None:
     if not symlink:
@@ -195,7 +195,10 @@ def _read_staged(
         return _common.check_reqdir(reqdir, jobsfs, StagedRequestDirError)
 
 
-def _check_staged_request(reqid: RequestID, reqfs) -> None:
+def _check_staged_request(
+        reqid: RequestID,
+        reqfs: _common.JobFS
+) -> None:
     # Check the request status.
     try:
         status = Result.read_status(str(reqfs.result.metadata))
@@ -215,7 +218,7 @@ def _check_staged_request(reqid: RequestID, reqfs) -> None:
 
 
 def _set_staged(
-        reqid: ToRequestIDType,
+        reqid: RequestID,
         reqdir: str,
         symlink: str,
         jobsfs: _common.JobsFS

--- a/PORTAL/jobs/_job.py
+++ b/PORTAL/jobs/_job.py
@@ -171,8 +171,8 @@ class Job:
     def _create(
             self,
             kind_kwargs: Mapping[str, Any],
-            pushfsattrs: Optional[_utils.FsAttrsType],
-            pullfsattrs: Optional[_utils.FsAttrsType],
+            pushfsattrs: Optional[_common.FsAttrsType],
+            pullfsattrs: Optional[_common.FsAttrsType],
             queue_log: str
     ):
         os.makedirs(self._fs.request.root, exist_ok=True)
@@ -204,8 +204,8 @@ class Job:
     def _build_send_script(
             self,
             queue_log: str,
-            pushfsfields: Optional[_utils.FsAttrsType] = None,
-            pullfsfields: Optional[_utils.FsAttrsType] = None,
+            pushfsfields: Optional[_common.FsAttrsType] = None,
+            pullfsfields: Optional[_common.FsAttrsType] = None,
             *,
             hidecfg: bool = False,
     ) -> str:

--- a/PORTAL/jobs/_job_compile_bench.py
+++ b/PORTAL/jobs/_job_compile_bench.py
@@ -178,6 +178,8 @@ class CompileBenchResult(Result):
         'pyperformance_results_orig',
     ]
 
+    _pyperf: _pyperformance.PyperfResults
+
     @classmethod
     def _extract_kwargs(
             cls,
@@ -209,11 +211,11 @@ class CompileBenchResult(Result):
         #self.pyperformance_results = pyperformance_results
         #self.pyperformance_results_orig = pyperformance_results_orig
 
-        self._pyperf: Optional[_pyperformance.PyperfResults] = None
-
     @property
     def pyperf(self) -> _pyperformance.PyperfResults:
-        if self._pyperf is None:
+        try:
+            return self._pyperf
+        except AttributeError:
             filename = self.fs.pyperformance_results
             resfile = _pyperformance.PyperfResultsFile(
                 filename,

--- a/PORTAL/jobs/_job_compile_bench.py
+++ b/PORTAL/jobs/_job_compile_bench.py
@@ -5,7 +5,7 @@ import textwrap
 from typing import Any, Iterable, List, Optional, Tuple, Union
 
 from . import _job
-from . import _utils, _pyperformance, _common
+from . import _utils, _pyperformance, _common, _workers
 from .requests import Request, RequestID, Result, ToRequestIDType
 from . import requests
 
@@ -591,11 +591,11 @@ class CompileBenchKind(_common.JobKind):
         #fs.pyperformance_results = f'{fs}/results-data.json.gz'
         fs.pyperformance_results = f'{fs}/pyperformance-results.json.gz'
 
-    def create(  # type: ignore[override]
+    def create(
             self,
             reqid: ToRequestIDType,
             jobfs: _job.JobFS,
-            workerfs: _utils.FSTree,
+            workerfs: _workers.WorkerJobsFS,
             *,
             _fake: Optional[Any] = None,
             **req_kwargs

--- a/PORTAL/jobs/_pyperformance.py
+++ b/PORTAL/jobs/_pyperformance.py
@@ -157,7 +157,7 @@ class Benchmarks:
                         break
                 else:
                     suite = default
-            if isinstance(suite, (str, type(None))):
+            if suite is None or isinstance(suite, str):
                 mapped[bench] = suite
             else:
                 raise TypeError(f"Invalid suite type {type(suite)}")
@@ -750,6 +750,7 @@ class _PyperfComparison:
 
     @classmethod
     def _parse_value(cls, valuestr: str) -> Any:
+        # Each subclass has a different return type for this function
         return _utils.ElapsedTimeWithUnits.parse(valuestr, fail=True)
 
     def __init__(
@@ -805,6 +806,7 @@ class _PyperfComparison:
         return self._source
 
     @property
+    # Dict values match the return type of _parse_value()
     def byname(self) -> Dict[str, Any]:
         return dict(self._byname)
 
@@ -829,8 +831,11 @@ class PyperfComparison(_PyperfComparison):
                          'bench baseline baseresult source result comparison')
 
     @classmethod
-    def _parse_value(cls, valuestr: str) -> Any:
-        return PyperfComparisonValue.parse(valuestr, fail=True)
+    def _parse_value(cls, valuestr: str) -> PyperfComparisonValue:
+        # Each subclass has a different return type for this function
+        result = PyperfComparisonValue.parse(valuestr, fail=True)
+        assert result is not None
+        return result
 
     def __init__(
             self,
@@ -886,16 +891,16 @@ class PyperfComparison(_PyperfComparison):
         return self._mean
 
     def look_up(self, name) -> "PyperfComparison.Summary":
-        time = self._byname[name]
-        assert isinstance(time, PyperfComparisonValue)
+        compared = self._byname[name]
+        assert isinstance(compared, PyperfComparisonValue)
 
         return self.Summary(
             name,
             self._baseline.source,
             self._baseline.byname[name],
             self._source,
-            time.elapsed,
-            time.comparison,
+            compared.elapsed,
+            compared.comparison,
         )
 
 

--- a/PORTAL/jobs/_pyperformance.py
+++ b/PORTAL/jobs/_pyperformance.py
@@ -1,20 +1,27 @@
 from collections import namedtuple
 import collections
+import datetime
 import gzip
 import hashlib
 import json
 import logging
 import os
 import os.path
-import platform
 import re
 import shutil
 import sys
+from typing import (
+    Any, Dict, Iterable, Iterator, List, Mapping, MutableMapping, Optional,
+    Sequence, Tuple, Union
+)
 
 from . import _utils
 
 
 logger = logging.getLogger(__name__)
+
+
+SuiteType = Union[None, str, _utils.Sentinel]
 
 
 ##################################
@@ -24,7 +31,13 @@ class BenchmarkSuiteInfo(
         namedtuple('BenchmarkSuiteInfo', 'name url reldir show_results')):
     """A single benchmark suite."""
 
-    def __new__(cls, name, url, reldir, show_results=False):
+    def __new__(
+            cls,
+            name: str,
+            url: str,
+            reldir: str,
+            show_results: bool = False
+    ):
         return super().__new__(
             cls,
             name=name,
@@ -43,7 +56,7 @@ class Benchmarks:
 
     PYPERFORMANCE = 'pyperformance'
     PYSTON = 'pyston'
-    SUITES = {
+    _SUITES = {
         PYPERFORMANCE: {
             'url': 'https://github.com/python/pyperformance',
             'reldir': 'pyperformance/data-files/benchmarks',
@@ -57,12 +70,17 @@ class Benchmarks:
             #'show_results': True,
         },
     }
-    for _suitename in SUITES:
-        SUITES[_suitename] = BenchmarkSuiteInfo(_suitename, **SUITES[_suitename])
+    SUITES: Dict[str, BenchmarkSuiteInfo] = {}
+    for _suitename in _SUITES:
+        SUITES[_suitename] = BenchmarkSuiteInfo(
+            _suitename,
+            **_SUITES[_suitename]  # type: ignore[arg-type]
+        )
     del _suitename
+    del _SUITES
 
     @classmethod
-    def _load_suite(cls, suite):
+    def _load_suite(cls, suite: str) -> List[str]:
         info = cls.SUITES[suite]
         url = info.url
         reldir = info.reldir
@@ -76,7 +94,7 @@ class Benchmarks:
         return list(names)
 
     @classmethod
-    def _get_names(cls, benchmarksdir):
+    def _get_names(cls, benchmarksdir: str) -> Iterable[str]:
         manifest = os.path.join(benchmarksdir, 'MANIFEST')
         if os.path.isfile(manifest):
             with open(manifest) as infile:
@@ -104,7 +122,7 @@ class Benchmarks:
                     yield name[3:]
 
     @classmethod
-    def _iter_subcandidates(cls, bench):
+    def _iter_subcandidates(cls, bench: str) -> Iterable[str]:
         # Some benchmarks actually produce results for
         # sub-benchmarks (e.g. logging -> logging_simple).
         while '_' in bench:
@@ -120,10 +138,15 @@ class Benchmarks:
     def __eq__(self, other):
         raise NotImplementedError
 
-    def get_suites(self, benchmarks, default=None):
-        mapped = {}
+    def get_suites(
+            self,
+            benchmarks: Iterable[str],
+            default: Optional[str] = None
+    ) -> Dict[str, Any]:
+        mapped: Dict[str, SuiteType] = {}
         by_bench = self.load('name')
         for bench in benchmarks:
+            suite: Any
             try:
                 suite = by_bench[bench]
             except KeyError:
@@ -136,7 +159,11 @@ class Benchmarks:
             mapped[bench] = suite
         return mapped
 
-    def get_suite(self, bench, default=None):
+    def get_suite(
+            self,
+            bench: str,
+            default: Optional[str] = None
+    ) -> Optional[str]:
         by_suite = self._cache if self._cache else self._load()
 
         suite = self._get_suite(bench, by_suite)
@@ -157,7 +184,7 @@ class Benchmarks:
         else:
             return None
 
-    def load(self, key='name'):
+    def load(self, key: str = 'name') -> Dict[str, List[str]]:
         """Return the per-suite lists of benchmarks."""
         by_suite = self._load()
         if key == 'suite':
@@ -191,6 +218,7 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
     EMPTY = _utils.Sentinel('empty')
     MULTI_SUITE = _utils.Sentinel('multi-suite')
     SUITES = set(Benchmarks.SUITES)
+    _SUITES: Dict[SuiteType, SuiteType]
     _SUITES = {s: s for s in SUITES}
     _SUITES[SUITE_NOT_KNOWN] = SUITE_NOT_KNOWN
     _SUITES[EMPTY] = EMPTY
@@ -218,8 +246,19 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
         $
     ''', re.VERBOSE)
 
+    _name: Optional[str] = None
+    _prefix: Optional[str] = None
+    _suffix: Optional[str] = None
+    _filename: Optional[str] = None
+    _dirname: Optional[str] = None
+
     @classmethod
-    def from_raw(cls, raw, *, fail=None):
+    def from_raw(
+            cls,
+            raw: Any,
+            *,
+            fail: Optional[bool] = None
+    ) -> Optional["PyperfUploadID"]:
         if not raw:
             if fail:
                 raise ValueError('missing uploadid')
@@ -237,7 +276,7 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
             return None
 
     @classmethod
-    def from_filename(cls, filename):
+    def from_filename(cls, filename: str) -> Optional["PyperfUploadID"]:
         # XXX Add a "checkexists" option?
         basename = os.path.basename(filename)
         self = cls._parse(basename)
@@ -249,7 +288,13 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
         return self
 
     @classmethod
-    def parse(cls, name, *, allowprefix=False, allowsuffix=False):
+    def parse(
+            cls,
+            name,
+            *,
+            allowprefix: bool = False,
+            allowsuffix: bool = False
+    ) -> Optional["PyperfUploadID"]:
         self = cls._parse(name)
         if self:
             if not allowprefix and self._prefix:
@@ -259,7 +304,7 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
         return self
 
     @classmethod
-    def _parse(cls, uploadid):
+    def _parse(cls, uploadid: str) -> Optional["PyperfUploadID"]:
         m = cls.REGEX.match(uploadid)
         if not m:
             return None
@@ -270,50 +315,65 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
             name = name[len(prefix):]
         if suffix:
             name = name[:-len(suffix)]
-        impl = _utils.resolve_python_implementation(impl)
+        resolved_impl = _utils.resolve_python_implementation(impl)
         if verstr == 'main':
-            version = impl.VERSION.resolve_main()
+            version = resolved_impl.VERSION.resolve_main()
             name = name.replace('-main-', f'-{version}-')
         else:
-            version = impl.parse_version(verstr)
-        self = cls(impl, version, commit, host, compatid, suite)
+            version = resolved_impl.parse_version(verstr)
+        self = cls(resolved_impl, version, commit, host, compatid, suite)
         self._name = name
         self._prefix = prefix or None
         self._suffix = suffix or None
         return self
 
     @classmethod
-    def from_metadata(cls, metadata, *,
-                      version=None,
-                      commit=None,
-                      host=None,
-                      impl=None,
-                      suite=None,
-                      ):
-        metadata = PyperfResultsMetadata.from_raw(metadata)
-        impl = _utils.resolve_python_implementation(
+    def from_metadata(
+            cls,
+            metadata: "PyperfResultsMetadata",
+            *,
+            version: Optional[Any] = None,
+            commit: Optional[str] = None,
+            host: Optional[_utils.HostInfo] = None,
+            impl: Optional[str] = None,
+            suite: Optional[Any] = None,
+    ) -> "PyperfUploadID":
+        resolved_metadata = PyperfResultsMetadata.from_raw(metadata)
+        if resolved_metadata is None:
+            raise ValueError("Couldn't load metadata")
+        resolved_impl = _utils.resolve_python_implementation(
             impl or metadata.python_implementation or 'cpython',
         )
         if not version:
             # We assume "main" if it's missing.
-            version = metadata.pyversion or 'main'
-        if version == 'main':
-            version = impl.VERSION.resolve_main()
+            normalized_version = metadata.pyversion or 'main'
         else:
-            version = impl.parse_version(version, requirestr=False)
+            normalized_version = version
+        if normalized_version == 'main':
+            resolved_version = resolved_impl.VERSION.resolve_main()
+        else:
+            resolved_version = resolved_impl.parse_version(
+                normalized_version,
+                requirestr=False
+            )
 
         self = cls(
-            impl=impl,
-            version=version,
-            commit=commit or metadata.commit,
-            host=host or metadata.host,
-            compatid=metadata.compatid,
+            impl=resolved_impl,
+            version=resolved_version,
+            commit=commit or resolved_metadata.commit,
+            host=host or resolved_metadata.host,
+            compatid=resolved_metadata.compatid,
             suite=suite,
         )
         return self
 
     @classmethod
-    def build_compatid(cls, host, pyperformance_version, pyperf_version=None):
+    def build_compatid(
+            cls,
+            host: _utils.HostInfo,
+            pyperformance_version: str,
+            pyperf_version: Optional[str] = None
+    ) -> str:
         if not host:
             raise ValueError('missing host')
         host = _utils.HostInfo.from_raw(host)
@@ -338,11 +398,15 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
         return h.hexdigest()
 
     @classmethod
-    def normalize_suite(cls, suite):
+    def normalize_suite(cls, suite: SuiteType) -> SuiteType:
         if not suite:
             return cls.SUITE_NOT_KNOWN
 
-        if not isinstance(suite, str) and _utils.iterable(suite):
+        if (
+                not isinstance(suite, str) and
+                _utils.iterable(suite) and
+                not isinstance(suite, _utils.Sentinel)
+        ):
             suites = list(suite)
             if len(suites) == 1:
                 suite, = suites
@@ -358,9 +422,15 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
         except KeyError:
             raise ValueError(f'unsupported suite {suite!r}')
 
-    def __new__(cls, impl, version, commit, host, compatid,
-                suite=SUITE_NOT_KNOWN,
-                ):
+    def __new__(
+            cls,
+            impl: _utils.PythonImplementation,
+            version: str,
+            commit: str,
+            host: Union[str, _utils.HostInfo],
+            compatid: str,
+            suite: SuiteType = SUITE_NOT_KNOWN,
+    ):
         return super().__new__(
             cls,
             impl=impl,
@@ -375,10 +445,8 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
         return self.name
 
     @property
-    def name(self):
-        try:
-            return self._name
-        except AttributeError:
+    def name(self) -> str:
+        if self._name is None:
             impl, version, commit, host, compatid, suite = self
             if isinstance(host, _utils.HostInfo):
                 host = host.id
@@ -386,29 +454,33 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
             if suite in self.SUITES:
                 name = f'{name}-{suite}'
             self._name = name
-            return name
+        return self._name
 
     @property
-    def implementation(self):
+    def implementation(self) -> str:
         return self.impl
 
     @property
-    def filename(self):
-        try:
-            return self._filename
-        except AttributeError:
-            filename, *_ = self.resolve_filenames()
-            return filename
+    def filename(self) -> str:
+        if self._filename is None:
+            self._filename, *_ = self.resolve_filenames()
+        return self._filename
 
     @property
-    def sortkey(self):
+    def sortkey(self) -> Tuple:
         # We leave commit and suite out.
         return (self.impl, self.version, self.host, self.compatid)
 
-    def resolve_filenames(self, *, dirname=True, prefix=True, suffix=True):
-        dirnames = []
+    def resolve_filenames(
+            self,
+            *,
+            dirname: Union[bool, str, Iterable[str]] = True,
+            prefix: Optional[Union[bool, str, Iterable[str]]] = True,
+            suffix: Optional[Union[bool, str, Iterable[str]]] = True
+    ) -> Iterable[str]:
+        dirnames: List[str] = []
         if dirname is True:
-            if hasattr(self, '_dirname') and self._dirname:
+            if self._dirname is not None:
                 dirnames = [self._dirname]
         elif dirname:
             if isinstance(dirname, str):
@@ -418,9 +490,9 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
             if any(not d for d in dirnames):
                 raise ValueError(f'blank dirname in {dirname}')
 
-        prefixes = [None]
+        prefixes: List[Optional[str]] = [None]
         if prefix is True:
-            if hasattr(self, '_prefix') and self._prefix:
+            if self._prefix is not None:
                 prefixes = [self._prefix]
         elif prefix:
             if isinstance(prefix, str):
@@ -430,7 +502,7 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
             if any(not p for p in prefixes):
                 raise ValueError(f'blank prefix in {prefix}')
 
-        suffixes = [None]
+        suffixes: List[Optional[str]] = [None]
         if suffix is True:
             if hasattr(self, '_suffix') and self._suffix:
                 suffixes = [self._suffix]
@@ -448,12 +520,16 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
             for prefix in prefixes:
                 filename = f'{prefix or ""}{name}{suffix or ""}'
                 if dirnames:
-                    for dirname in dirnames:
-                        yield os.path.join(dirname, filename)
+                    for dirname_element in dirnames:
+                        yield os.path.join(dirname_element, filename)
                 else:
                     yield filename
 
-    def match(self, specifier, suites=None):
+    def match(
+            self,
+            specifier: Any,
+            suites=None
+    ) -> bool:
         # specifier: uploadID, version, filename
         matched = self._match(specifier, checksuite=(not suites))
         if matched and suites:
@@ -469,7 +545,7 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
                 return False
         return matched
 
-    def _match(self, specifier, checksuite):
+    def _match(self, specifier: Any, checksuite) -> bool:
         requested = self.from_raw(specifier, fail=False)
         if requested:
             if not checksuite:
@@ -483,15 +559,17 @@ class PyperfUploadID(namedtuple('PyperfUploadName',
         #    return True
         return False
 
-    def _match_version(self, version):
+    def _match_version(self, version: Union[str, _utils.Version]) -> bool:
         if isinstance(version, str):
-            version = _utils.Version.parse(version)
+            version_obj = _utils.Version.parse(version)
             if not version:
                 return False
         elif not isinstance(version, _utils.Version):
             return False
+        else:
+            version_obj = version
         # XXX Treat missing micro/release as wildcard?
-        return version.full == self.version.full
+        return version_obj.full == self.version.full
 
     #def _match_pattern(self, pat, checksuite):
     #    raise NotImplementedError
@@ -553,7 +631,12 @@ class PyperfComparisonValue:
     ''', re.VERBOSE)
 
     @classmethod
-    def parse(cls, valuestr, *, fail=False):
+    def parse(
+            cls,
+            valuestr: str,
+            *,
+            fail: bool = False
+    ) -> Optional["PyperfComparisonValue"]:
         m = cls.REGEX.match(valuestr)
         if not m:
             if fail:
@@ -583,7 +666,11 @@ class PyperfComparisonValue:
             raise NotImplementedError(valuestr)
         return cls(elapsed, comparison)
 
-    def __init__(self, elapsed, comparison):
+    def __init__(
+            self,
+            elapsed: Optional[_utils.ElapsedTimeWithUnits] = None,
+            comparison: Optional[_utils.ElapsedTimeComparison] = None
+    ):
         self._elapsed = elapsed
         self._comparison = comparison
 
@@ -615,15 +702,15 @@ class PyperfComparisonValue:
         return True
 
     @property
-    def elapsed(self):
+    def elapsed(self) -> Optional[_utils.ElapsedTimeWithUnits]:
         return self._elapsed
 
     @property
-    def comparison(self):
+    def comparison(self) -> Optional[_utils.ElapsedTimeComparison]:
         return self._comparison
 
     @property
-    def isbaseline(self):
+    def isbaseline(self) -> bool:
         if self._elapsed and not self._comparison:
             return True
         return self._comparison == self.BASELINE
@@ -631,10 +718,15 @@ class PyperfComparisonValue:
 
 class _PyperfComparison:
 
-    kind = None
+    kind: Optional[str] = None
 
     @classmethod
-    def from_raw(cls, raw, *, fail=None):
+    def from_raw(
+            cls,
+            raw: Any,
+            *,
+            fail: Optional[bool] = None
+    ) -> Optional["_PyperfComparison"]:
         if not raw:
             if fail:
                 raise ValueError(f'missing {cls.kind}')
@@ -647,16 +739,20 @@ class _PyperfComparison:
             return None
 
     @classmethod
-    def _parse_value(cls, valuestr):
+    def _parse_value(cls, valuestr: str) -> _utils.ElapsedTimeWithUnits:
         return _utils.ElapsedTimeWithUnits.parse(valuestr, fail=True)
 
-    def __init__(self, source, byname=None):
+    def __init__(
+            self,
+            source: Any,
+            byname: Optional[Dict[str, str]] = None
+    ):
         _utils.check_str(source, 'source', required=True, fail=True)
         if not os.path.isabs(source):
             raise ValueError(f'expected an absolute source, got {source!r}')
         # XXX Further validate source as a filename?
 
-        _byname = {}
+        _byname: Dict[str, _utils.ElapsedTimeWithUnits] = {}
         if byname:
             for name, value in byname.items():
                 assert name and isinstance(name, str), (name, value, byname)
@@ -688,18 +784,18 @@ class _PyperfComparison:
             return False
         return True
 
-    def _as_hashable(self):
+    def _as_hashable(self) -> Tuple:
         return (
             self._source,
             tuple(sorted(self._byname.items())) if self._byname else (),
         )
 
     @property
-    def source(self):
+    def source(self) -> str:
         return self._source
 
     @property
-    def byname(self):
+    def byname(self) -> Dict[str, _utils.ElapsedTimeWithUnits]:
         return dict(self._byname)
 
 
@@ -723,10 +819,16 @@ class PyperfComparison(_PyperfComparison):
                          'bench baseline baseresult source result comparison')
 
     @classmethod
-    def _parse_value(cls, valuestr):
+    def _parse_value(cls, valuestr: str):
         return PyperfComparisonValue.parse(valuestr, fail=True)
 
-    def __init__(self, baseline, source, mean, byname=None):
+    def __init__(
+            self,
+            baseline: Any,
+            source: Any,
+            mean: Any,
+            byname: Optional[Dict[str, str]] = None
+    ):
         super().__init__(source, byname)
         baseline = PyperfComparisonBaseline.from_raw(baseline, fail=True)
         if self._byname and sorted(self._byname) != sorted(baseline.byname):
@@ -766,36 +868,43 @@ class PyperfComparison(_PyperfComparison):
         )
 
     @property
-    def baseline(self):
+    def baseline(self) -> PyperfComparisonBaseline:
         return self._baseline
 
     @property
-    def mean(self):
+    def mean(self) -> Optional[_utils.ElapsedTimeComparison]:
         return self._mean
 
-    def look_up(self, name):
-        return self.Summary(
-            name,
-            self._baseline.source,
-            self._baseline.byname[name],
-            self._source,
-            self._byname[name].elapsed,
-            self._byname[name].comparison,
-        )
+    # TYPE - BROKEN
+    # def look_up(self, name) -> "PyperfComparison.Summary":
+    #     return self.Summary(
+    #         name,
+    #         self._baseline.source,
+    #         self._baseline.byname[name],
+    #         self._source,
+    #         self._byname[name].elapsed,
+    #         self._byname[name].comparison,
+    #     )
 
 
 class PyperfComparisons:
     """The baseline and comparisons for a set of results."""
 
     @classmethod
-    def parse_table(cls, text, filenames=None):
+    def parse_table(
+            cls,
+            text: str,
+            filenames: Optional[Iterable[str]] = None
+    ) -> "PyperfComparisons":
         table = PyperfTable.parse(text, filenames)
+        if table is None:
+            raise ValueError("Could not parse table")
         return cls.from_table(table)
 
     @classmethod
-    def from_table(cls, table):
+    def from_table(cls, table: "PyperfTable") -> "PyperfComparisons":
         base_byname = {}
-        bysource = {s: {} for s in table.header.others}
+        bysource: Dict[str, Any] = {s: {} for s in table.header.others}
         means = {s: None for s in table.header.others}
         for row in table.rows:
             values = row.valuesdict
@@ -816,7 +925,11 @@ class PyperfComparisons:
         self._table = table
         return self
 
-    def __init__(self, baseline, bysource):
+    def __init__(
+            self,
+            baseline: PyperfComparisonBaseline,
+            bysource: Mapping[str, dict]
+    ):
         # baseline is checked in PyperfComparison.__init__().
         if not bysource:
             raise ValueError('missing bysource')
@@ -826,30 +939,36 @@ class PyperfComparisons:
             _bysource[source] = PyperfComparison(baseline, source, mean, byname)
         self._baseline = baseline
         self._bysource = _bysource
+        self._table: Optional["PyperfTable"] = None
 
     def __eq__(self, other):
         raise NotImplementedError
 
     @property
-    def baseline(self):
+    def baseline(self) -> PyperfComparisonBaseline:
         return self._baseline
 
     @property
-    def bysource(self):
+    def bysource(self) -> Dict[str, Any]:
         return dict(self._bysource)
 
     @property
-    def table(self):
-        try:
-            return self._table
-        except AttributeError:
+    def table(self) -> "PyperfTable":
+        if self._table is None:
             raise NotImplementedError
+        return self._table
 
 
 class PyperfTableParserError(ValueError):
     MSG = 'failed parsing results table'
     FIELDS = 'text reason'.split()
-    def __init__(self, text, reason=None, msg=None):
+
+    def __init__(
+            self,
+            text: Optional[str],
+            reason: Optional[str] = None,
+            msg: Optional[str] = None
+    ):
         self.text = text
         self.reason = reason
         if not msg:
@@ -864,20 +983,28 @@ class PyperfTableRowParserError(PyperfTableParserError):
     MSG = 'failed parsing table row line {line!r}'
     FIELDS = 'line'.split()
     FIELDS = PyperfTableParserError.FIELDS + FIELDS
-    def __init__(self, line, reason=None, msg=None):
+
+    def __init__(
+            self,
+            line: str,
+            reason: Optional[str] = None,
+            msg: Optional[str] = None
+    ):
         self.line = line
         super().__init__(line, reason, msg)
 
 
 class PyperfTableRowUnsupportedLineError(PyperfTableRowParserError):
     MSG = 'unsupported table row line {line!r}'
-    def __init__(self, line, msg=None):
+
+    def __init__(self, line: str, msg: Optional[str] = None):
         super().__init__(line, 'unsupported', msg)
 
 
 class PyperfTableRowInvalidLineError(PyperfTableRowParserError):
     MSG = 'invalid table row line {line!r}'
-    def __init__(self, line, msg=None):
+
+    def __init__(self, line: str, msg: Optional[str] = None):
         super().__init__(line, 'invalid', msg)
 
 
@@ -886,7 +1013,11 @@ class PyperfTable:
     FORMATS = ['raw', 'meanonly']
 
     @classmethod
-    def parse(cls, text, filenames=None):
+    def parse(
+            cls,
+            text: str,
+            filenames: Optional[Iterable[str]] = None
+    ) -> Optional["PyperfTable"]:
         lines = iter(text.splitlines())
         # First parse the header.
         for line in lines:
@@ -916,7 +1047,7 @@ class PyperfTable:
                     # end-of-table
                     ignored, _ = cls._parse_ignored(line, lines)
                     # XXX Add the names to the table.
-                    line = _utils.get_next_line(lines, skipempty=True)
+                    line = _utils.get_next_line(lines, skipempty=True) or ''
                     break
                 elif not line.startswith('#'):
                     raise  # re-raise
@@ -933,7 +1064,12 @@ class PyperfTable:
         return self
 
     @classmethod
-    def _parse_names_list(cls, line, lines, prefix=None):
+    def _parse_names_list(
+            cls,
+            line: Optional[str],
+            lines: Iterator[str],
+            prefix: Optional[str] = None
+    ) -> Tuple[Optional[List[str]], Optional[str]]:
         while not line:
             try:
                 line = next(lines)
@@ -952,7 +1088,12 @@ class PyperfTable:
         return names, line
 
     @classmethod
-    def _parse_ignored(cls, line, lines, required=True):
+    def _parse_ignored(
+            cls,
+            line: Optional[str],
+            lines: Iterator[str],
+            required: bool = True
+    ) -> Tuple[Optional[List[str]], Optional[str]]:
         # Ignored benchmarks (2) of benchmark-results/cpython-3.10.4-9d38120e33-fc_linux-42d6dd4409cb.json: genshi_text, genshi_xml
         prefix = r'Ignored benchmarks \((\d+)\) of \w+.*\w'
         names, line = cls._parse_names_list(line, lines, prefix)
@@ -961,7 +1102,12 @@ class PyperfTable:
         return names, line
 
     @classmethod
-    def _parse_hidden(cls, line, lines, required=True):
+    def _parse_hidden(
+            cls,
+            line: Optional[str],
+            lines: Iterator[str],
+            required: bool = True
+    ) -> Tuple[Optional[List[str]], Optional[str]]:
         # Benchmark hidden because not significant (6): unpickle, scimark_sor, sqlalchemy_imperative, sqlite_synth, json_loads, xml_etree_parse
         prefix = r'Benchmark hidden because not significant \((\d+)\)'
         names, line = cls._parse_names_list(line, lines, prefix)
@@ -969,7 +1115,7 @@ class PyperfTable:
             raise PyperfTableParserError(line, 'expected "Benchmarks hidden..."')
         return names, line
 
-    def __init__(self, rows, header=None):
+    def __init__(self, rows: Any, header: Any = None):
         if not isinstance(rows, tuple):
             rows = tuple(rows)
         if not header:
@@ -978,6 +1124,8 @@ class PyperfTable:
             raise ValueError(f'unsupported header {header}')
         self.header = header
         self.rows = rows
+        self._mean_row: Optional["PyperfTableRow"] = None
+        self._text: Optional[str] = None
 
     def __repr__(self):
         return f'{type(self).__name__}({self.rows}, {self.header})'
@@ -986,19 +1134,17 @@ class PyperfTable:
         raise NotImplementedError
 
     @property
-    def mean_row(self):
-        try:
-            return self._mean_row
-        except AttributeError:
+    def mean_row(self) -> "PyperfTableRow":
+        if self._mean_row is None:
             for row in self.rows:
                 if row.name == 'Geometric mean':
                     break
             else:
                 row = None
             self._mean_row = row
-            return self._mean_row
+        return self._mean_row
 
-    def render(self, fmt=None):
+    def render(self, fmt: Optional[str] = None) -> Iterable[str]:
         if not fmt:
             fmt = 'raw'
         if fmt == 'raw':
@@ -1031,9 +1177,16 @@ class PyperfTable:
 
 
 class _PyperfTableRowBase(tuple):
+    _raw: Optional[str] = None
+    _header: Optional[List[str]] = None
 
     @classmethod
-    def parse(cls, line, *, fail=False):
+    def parse(
+            cls,
+            line: str,
+            *,
+            fail: bool = False
+    ) -> Optional["_PyperfTableRowBase"]:
         values = cls._parse(line, fail)
         if not values:
             return None
@@ -1042,7 +1195,7 @@ class _PyperfTableRowBase(tuple):
         return self
 
     @classmethod
-    def _parse(cls, line, fail=False):
+    def _parse(cls, line: str, fail: bool = False) -> Optional[Tuple]:
         line = line.rstrip()
         if line.startswith('+'):
             return None
@@ -1061,42 +1214,26 @@ class _PyperfTableRowBase(tuple):
         raise TypeError(f'not supported; use {cls.__name__}.parse() instead')
 
     @property
-    def raw(self):
+    def raw(self) -> Optional[str]:
         return self._raw
 
     @property
-    def name(self):
-        try:
-            return self._name
-        except AttributeError:
-            self._name = self[0]
-            return self._name
+    def name(self) -> str:
+        return self[0]
 
     @property
-    def values(self):
-        try:
-            return self._values
-        except AttributeError:
-            self._values = self[1:]
-            return self._values
+    def values(self) -> Tuple:
+        return self[1:]
 
     @property
-    def baseline(self):
-        try:
-            return self._baseline
-        except AttributeError:
-            self._baseline = self[1]
-            return self._baseline
+    def baseline(self) -> str:
+        return self[1]
 
     @property
-    def others(self):
-        try:
-            return self._others
-        except AttributeError:
-            self._others = self[2:]
-            return self._others
+    def others(self) -> Tuple:
+        return self[2:]
 
-    def render(self, fmt=None):
+    def render(self, fmt: Optional[str] = None) -> str:
         if not fmt:
             fmt = 'raw'
         if fmt == 'raw':
@@ -1114,7 +1251,13 @@ class PyperfTableHeader(_PyperfTableRowBase):
     sources = _PyperfTableRowBase.values
 
     @classmethod
-    def parse(cls, line, filenames=None, *, fail=False):
+    def parse(
+            cls,
+            line: str,
+            filenames: Optional[Iterable[str]] = None,
+            *,
+            fail: bool = False
+    ):
         self = super().parse(line, fail=fail)
         if not self:
             return None
@@ -1128,22 +1271,26 @@ class PyperfTableHeader(_PyperfTableRowBase):
         return self
 
     @property
-    def div(self):
+    def div(self) -> str:
         return '+=' + '=+='.join('=' * len(v) for v in self) + '=+'
 
     @property
-    def rowdiv(self):
+    def rowdiv(self) -> str:
         return '+-' + '-+-'.join('-' * len(v) for v in self) + '-+'
 
-    @property
-    def indexpersource(self):
-        return dict(zip(self.sources, range(len(self.sources))))
+    # TYPE: BROKEN
+    # @property
+    # def indexpersource(self) -> Dict[str, Iterable[int]]:
+    #     return dict(zip(self.sources, range(len(self.sources))))
 
 
 class PyperfTableRow(_PyperfTableRowBase):
 
     @classmethod
-    def subclass_from_header(cls, header):
+    def subclass_from_header(
+            cls,
+            header: None
+    ) -> "PyperfTableRow":
         if cls is not PyperfTableRow:
             raise TypeError('not supported for subclasses')
         if not header:
@@ -1155,25 +1302,32 @@ class PyperfTableRow(_PyperfTableRowBase):
         return _PyperfTableRow
 
     @classmethod
-    def parse(cls, line, header, fail=False):
+    def parse(
+            cls,
+            line: str,
+            header: Optional[List[str]] = None,
+            fail: bool = False
+    ):
         self = super().parse(line, fail=fail)
         if not self:
             return None
-        if len(self) != len(header):
+        if header is not None and len(self) != len(header):
             raise ValueError(f'expected {len(header)} values, got {tuple(self)}')
         self._header = header
         return self
 
     @property
-    def header(self):
+    def header(self) -> Optional[List[str]]:
         return self._header
 
-    @property
-    def valuesdict(self):
-        return dict(zip(self.header.sources, self.values))
+    # TYPE: BROKEN
+    # @property
+    # def valuesdict(self):
+    #     return dict(zip(self.header.sources, self.values))
 
-    def look_up(self, source):
-        return self.valuesdict[source]
+    # TYPE: BROKEN
+    # def look_up(self, source):
+    #     return self.valuesdict[source]
 
 
 ##################################
@@ -1184,23 +1338,29 @@ class PyperfResults:
     BENCHMARKS = Benchmarks()
 
     @classmethod
-    def get_metadata_raw(cls, data):
+    def get_metadata_raw(cls, data) -> Mapping[str, str]:
         return data['metadata']
 
     @classmethod
-    def iter_benchmarks_from_data(cls, data):
+    def iter_benchmarks_from_data(cls, data) -> Iterator[str]:
         yield from data['benchmarks']
 
     @classmethod
-    def get_benchmark_name(cls, benchdata):
+    def get_benchmark_name(cls, benchdata) -> str:
         return benchdata['metadata']['name']
 
     @classmethod
-    def get_benchmark_metadata_raw(cls, benchdata):
+    def get_benchmark_metadata_raw(
+            cls,
+            benchdata
+    ) -> MutableMapping[str, str]:
         return benchdata['metadata']
 
     @classmethod
-    def iter_benchmark_runs_from_data(cls, benchdata):
+    def iter_benchmark_runs_from_data(
+            cls,
+            benchdata
+    ) -> Iterator[Tuple[Mapping[str, str], List[float], List[float]]]:
         for rundata in benchdata['runs']:
             yield (
                 rundata['metadata'],
@@ -1209,7 +1369,7 @@ class PyperfResults:
             )
 
     @classmethod
-    def _validate_data(cls, data):
+    def _validate_data(cls, data) -> None:
         if data['version'] == '1.0':
             for key in ('metadata', 'benchmarks', 'version'):
                 if key not in data:
@@ -1218,7 +1378,7 @@ class PyperfResults:
         else:
             raise NotImplementedError(data['version'])
 
-    def __init__(self, data, resfile):
+    def __init__(self, data, resfile: Any):
         if not data:
             raise ValueError('missing data')
         if not resfile:
@@ -1226,8 +1386,12 @@ class PyperfResults:
         self._validate_data(data)
         self._data = data
         self._resfile = PyperfResultsFile.from_raw(resfile)
+        self._metadata: Optional["PyperfResultsMetadata"] = None
+        self._uploadid: Optional["PyperfUploadID"] = None
+        self._by_bench: Optional[Mapping[str, Any]] = None
+        self._by_suite: Optional[Mapping[SuiteType, Any]] = None
 
-    def _copy(self):
+    def _copy(self) -> "PyperfResults":
         cls = type(self)
         copied = cls.__new__(cls)
         copied._data = self._data
@@ -1238,53 +1402,53 @@ class PyperfResults:
         raise NotImplementedError
 
     @property
-    def data(self):
+    def data(self) -> Mapping[str, Any]:
         return self._data
 
     @property
-    def raw(self):
+    def raw(self) -> Mapping[str, Any]:
         return self._data
 
     @property
-    def raw_metadata(self):
+    def raw_metadata(self) -> Mapping[str, str]:
         return self._data['metadata']
 
     @property
-    def raw_benchmarks(self):
+    def raw_benchmarks(self) -> List[Mapping[str, Any]]:
         return self._data['benchmarks']
 
     @property
-    def metadata(self):
-        try:
-            return self._metadata
-        except AttributeError:
+    def metadata(self) -> "PyperfResultsMetadata":
+        if self._metadata is None:
             self._metadata = PyperfResultsMetadata.from_full_results(self._data)
-            return self._metadata
+        return self._metadata
 
     @property
-    def version(self):
+    def version(self) -> str:
         return self._data['version']
 
     @property
-    def resfile(self):
+    def resfile(self) -> Optional["PyperfResultsFile"]:
         return self._resfile
 
     @property
-    def filename(self):
+    def filename(self) -> str:
+        if self._resfile is None:
+            raise ValueError
         return self._resfile.filename
 
     @property
-    def date(self):
+    def date(self) -> datetime.datetime:
         run0 = self.raw_benchmarks[0]['runs'][0]
         date = run0['metadata']['date']
         date, _ = _utils.get_utc_datetime(date)
         return date
 
     @property
-    def uploadid(self):
-        try:
-            return self._uploadid
-        except AttributeError:
+    def uploadid(self) -> PyperfUploadID:
+        if self._uploadid is None:
+            if self._resfile is None:
+                raise ValueError
             if self._resfile.uploadid:
                 # XXX Compare with what we get from the metadata?
                 self._uploadid = self._resfile.uploadid
@@ -1293,34 +1457,30 @@ class PyperfResults:
                     self.metadata,
                     suite=self.suites,
                 )
-            return self._uploadid
+        return self._uploadid
 
     @property
-    def suite(self):
+    def suite(self) -> str:
         return self.uploadid.suite
 
     @property
-    def suites(self):
-        return sorted(self.by_suite)
+    def suites(self) -> Iterable[SuiteType]:
+        return sorted(self.by_suite)  # type: ignore[type-var] 
 
     @property
-    def by_bench(self):
-        try:
-            return self._by_bench
-        except AttributeError:
+    def by_bench(self) -> Mapping[str, Any]:
+        if self._by_bench is None:
             self._by_bench = dict(self._iter_benchmarks())
-            return self._by_bench
+        return self._by_bench
 
     @property
-    def by_suite(self):
-        try:
-            return self._by_suite
-        except AttributeError:
+    def by_suite(self) -> Mapping[SuiteType, Any]:
+        if self._by_suite is None:
             self._by_suite = self._collate_suites()
-            return self._by_suite
+        return self._by_suite
 
-    def _collate_suites(self):
-        by_suite = {}
+    def _collate_suites(self) -> Mapping[SuiteType, Any]:
+        by_suite: Dict[SuiteType, Any] = {}
         names = [n for n, _ in self._iter_benchmarks()]
         if names:
             bench_suites = self.BENCHMARKS.get_suites(names, 'unknown')
@@ -1335,12 +1495,12 @@ class PyperfResults:
             logger.warn(f'empty results {self}')
         return by_suite
 
-    def _iter_benchmarks(self):
+    def _iter_benchmarks(self) -> Iterator[Tuple[str, Any]]:
         for benchdata in self.iter_benchmarks_from_data(self._data):
             name = self.get_benchmark_name(benchdata)
             yield name, benchdata
 
-    def split_benchmarks(self):
+    def split_benchmarks(self) -> Mapping[SuiteType, "PyperfResults"]:
         """Return results collated by suite."""
         if self.suite is not PyperfUploadID.MULTI_SUITE:
             assert self.suite is not PyperfUploadID.SUITE_NOT_KNOWN
@@ -1351,18 +1511,26 @@ class PyperfResults:
                                for k, v in self._data.items()
                                if k != 'benchmarks'}
             by_suite[suite]['benchmarks'] = benchmarks
-        cls = type(self)
+        by_suite_resolved = {}
         for suite, data in by_suite.items():
             results = self._copy()
             results._data = data
             results._by_suite = {suite: data['benchmarks'][0]}
-            by_suite[suite] = results
-        return by_suite
+            by_suite_resolved[suite] = results
+        return by_suite_resolved
 
     #def compare(self, others):
     #    raise NotImplementedError
 
-    def copy_to(self, filename, resultsroot=None, *, compressed=None):
+    def copy_to(
+            self,
+            filename: str,
+            resultsroot: Optional[str] = None,
+            *,
+            compressed: bool = False 
+    ) -> "PyperfResults":
+        if self._resfile is None:
+            raise ValueError
         if os.path.exists(self._resfile.filename):
             resfile = self._resfile.copy_to(filename, resultsroot,
                                             compressed=compressed)
@@ -1376,6 +1544,10 @@ class PyperfResults:
 
 
 class PyperfResultsMetadata:
+
+    _topdata: Optional[Any] = None
+    _benchdata: Optional[Any] = None
+    _benchmarks: Optional[List[Any]] = None
 
     _EXPECTED_TOP = {
         "aslr",
@@ -1409,7 +1581,10 @@ class PyperfResultsMetadata:
     EXPECTED = _EXPECTED_TOP | _EXPECTED_BENCH
 
     @classmethod
-    def from_raw(cls, raw):
+    def from_raw(
+            cls,
+            raw: Optional["PyperfResultsMetadata"]
+    ) -> Optional["PyperfResultsMetadata"]:
         if not raw:
             return None
         elif isinstance(raw, cls):
@@ -1418,7 +1593,10 @@ class PyperfResultsMetadata:
             raise TypeError(raw)
 
     @classmethod
-    def from_full_results(cls, data):
+    def from_full_results(
+            cls,
+            data: Mapping[str, Any]
+    ) -> "PyperfResultsMetadata":
         topdata = data['metadata']
         benchdata = cls._merge_from_benchmarks(data['benchmarks'], topdata)
         metadata = collections.ChainMap(topdata, benchdata)
@@ -1429,12 +1607,29 @@ class PyperfResultsMetadata:
         return self
 
     @classmethod
-    def overwrite_raw(cls, data, field, value, *, addifnotset=True):
-        _, modified = cls._overwrite(data['metadata'], field, value, addifnotset)
+    def overwrite_raw(
+            cls,
+            data: Mapping[str, Any],
+            field: str,
+            value: Any,
+            *,
+            addifnotset: bool = True
+    ) -> bool:
+        _, modified = cls._overwrite(
+            data['metadata'],
+            field,
+            value,
+            addifnotset=addifnotset
+        )
         return modified
 
     @classmethod
-    def overwrite_raw_all(cls, data, field, value):
+    def overwrite_raw_all(
+            cls,
+            data: Mapping[str, Any],
+            field: str,
+            value: Any
+    ) -> bool:
         _, modified = cls._overwrite(data['metadata'], field, value)
         for benchdata in PyperfResults.iter_benchmarks_from_data(data):
             name = PyperfResults.get_benchmark_name(benchdata)
@@ -1448,7 +1643,14 @@ class PyperfResultsMetadata:
         return modified
 
     @classmethod
-    def _overwrite(cls, data, field, value, context=None, addifnotset=True):
+    def _overwrite(
+            cls,
+            data: MutableMapping[str, Any],
+            field: str,
+            value: Any,
+            context: Optional[str] = None,
+            addifnotset: bool = True
+    ) -> Tuple["PyperfResultsMetadata", bool]:
         context = f' for {context}' if context else ''
         try:
             old = data[field]
@@ -1469,8 +1671,12 @@ class PyperfResultsMetadata:
         return old, modified
 
     @classmethod
-    def _merge_from_benchmarks(cls, data, topdata):
-        metadata = {}
+    def _merge_from_benchmarks(
+            cls,
+            data: List[Mapping[str, Any]],
+            topdata: Mapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        metadata: MutableMapping[str, Any] = {}
         for bench in data:
             for key, value in bench['metadata'].items():
                 if key not in cls.EXPECTED:
@@ -1494,9 +1700,14 @@ class PyperfResultsMetadata:
                 del metadata[key]
         return metadata
 
-    def __init__(self, data, version=None):
+    def __init__(self, data, version: Optional[str] = None):
         self._data = data
         self._version = version
+        self._python_implementation: Optional[
+            _utils.PythonImplementation
+        ] = None
+        self._pyversion: Optional[None] = None 
+        self._host: Optional[_utils.HostInfo] = None 
 
     def __eq__(self, other):
         raise NotImplementedError
@@ -1508,37 +1719,32 @@ class PyperfResultsMetadata:
         yield from self._data
 
     @property
-    def data(self):
+    def data(self) -> Mapping[str, Any]:
         return self._data
 
     @property
-    def version(self):
+    def version(self) -> Optional[str]:
         return self._version
 
     @property
-    def commit(self):
+    def commit(self) -> str:
         return self._data['commit_id']
 
     @property
-    def python_implementation(self):
-        try:
-            return self._python_implementation
-        except AttributeError:
-            impl = _utils.resolve_python_implementation(
+    def python_implementation(self) -> _utils.PythonImplementation:
+        if self._python_implementation is None:
+            self._python_implementation = _utils.resolve_python_implementation(
                 self._data.get('python_implementation'),
             )
-            self._python_implementation = impl
-            return impl
+        return self._python_implementation
 
     @property
-    def pyversion(self):
-        try:
-            return self._pyversion
-        except AttributeError:
+    def pyversion(self) -> None:
+        if self._pyversion is None:
             text = self._data.get('python_version')
             impl = self.python_implementation
             parsed = impl.parse_version(text)
-            if not parsed and hasattr(impl.VERSION, 'parse_extended'):
+            if not parsed and isinstance(impl.VERSION, _utils.CPythonVersion):
                 parsed = impl.VERSION.parse_extended(text)
                 if parsed:
                     parsed, _, _ = parsed
@@ -1548,19 +1754,17 @@ class PyperfResultsMetadata:
             if not parsed:
                 parsed = None
             self._pyversion = parsed
-            return parsed
+        return self._pyversion
 
     @property
-    def build(self):
+    def build(self) -> List[str]:
         # XXX Add to PyperfUploadID?
         # XXX Extract from self._data?
         return ['PGO', 'LTO']
 
     @property
-    def host(self):
-        try:
-            return self._host
-        except AttributeError:
+    def host(self) -> _utils.HostInfo:
+        if self._host is None:
             self._host = _utils.HostInfo.from_metadata(
                 self._data.get('hostid'),
                 self._data['hostname'],
@@ -1572,10 +1776,10 @@ class PyperfResultsMetadata:
                 self._data.get('cpu_count'),
                 self._data.get('cpu_affinity'),
             )
-            return self._host
+        return self._host
 
     @property
-    def compatid(self):
+    def compatid(self) -> str:
         raw = self.host.as_metadata()
         return PyperfUploadID.build_compatid(
             self.host,
@@ -1583,7 +1787,7 @@ class PyperfResultsMetadata:
             self._data.get('perf_version'),
         )
 
-    def overwrite(self, field, value):
+    def overwrite(self, field: str, value: Any) -> "PyperfResultsMetadata":
         old, _ = self._overwrite(self._data, field, value)
         return old
 
@@ -1592,7 +1796,11 @@ class PyperfResultsInfo(
         namedtuple('PyperfResultsInfo', 'uploadid build filename compared')):
 
     @classmethod
-    def from_results(cls, results, compared=None):
+    def from_results(
+            cls,
+            results: PyperfResults,
+            compared: Optional[_PyperfComparison] = None
+    ) -> "PyperfResultsInfo":
         if not isinstance(results, PyperfResults):
             raise NotImplementedError(results)
         resfile = results.resfile
@@ -1609,7 +1817,11 @@ class PyperfResultsInfo(
         return self
 
     @classmethod
-    def from_resultsfile(cls, resfile, compared=None):
+    def from_resultsfile(
+            cls,
+            resfile: "PyperfResultsFile",
+            compared: Optional[_PyperfComparison] = None
+    ) -> Tuple["PyperfResultsInfo", "PyperfResults"]:
         if not resfile:
             raise ValueError('missing resfile')
         elif not isinstance(resfile, PyperfResultsFile):
@@ -1621,21 +1833,40 @@ class PyperfResultsInfo(
         return self, results
 
     @classmethod
-    def from_file(cls, filename, resultsroot=None, compared=None):
+    def from_file(
+            cls,
+            filename: str,
+            resultsroot: Optional[str] = None,
+            compared: Optional[_PyperfComparison] = None
+    ) -> Tuple["PyperfResultsInfo", "PyperfResults"]:
         resfile = PyperfResultsFile(filename, resultsroot)
         return cls.from_resultsfile(resfile, compared)
 
     @classmethod
-    def from_values(cls, uploadid, build=None, filename=None, compared=None,
-                    resultsroot=None, date=None):
+    def from_values(
+            cls,
+            uploadid: Any,
+            build: Optional[Union[str, List[str]]] = None,
+            filename: Optional[str] = None,
+            compared: Optional[_PyperfComparison] = None,
+            resultsroot: Optional[str] = None,
+            date: Optional[datetime.datetime] = None
+    ) -> "PyperfResultsInfo":
         uploadid = PyperfUploadID.from_raw(uploadid, fail=True)
         build = cls._normalize_build(build)
         return cls._from_values(
             uploadid, build, filename, compared, resultsroot, date)
 
     @classmethod
-    def _from_values(cls, uploadid, build, filename, compared,
-                     resultsroot, date):
+    def _from_values(
+            cls,
+            uploadid: Any,
+            build: Optional[List[str]],
+            filename: Optional[str],
+            compared: Optional[_PyperfComparison],
+            resultsroot: Optional[str],
+            date: Optional[datetime.datetime]
+    ) -> "PyperfResultsInfo":
         if filename:
             (filename, relfile, resultsroot,
              ) = normalize_results_filename(filename, resultsroot)
@@ -1652,18 +1883,20 @@ class PyperfResultsInfo(
         return self
 
     @classmethod
-    def _normalize_build(cls, build):
+    def _normalize_build(
+            cls,
+            build: Optional[Union[str, List[str]]]
+    ) -> Optional[List[str]]:
         if not build:
-            return build
+            return None
         if isinstance(build, str):
             # "PGO,LTO"
             build = build.split(',')
-        build = tuple(build)
         cls._validate_build_values(build)
         return build
 
     @classmethod
-    def _validate_build_values(cls, values):
+    def _validate_build_values(cls, values: List[str]) -> None:
         for i, value in enumerate(values):
             if not value:
                 raise ValueError(f'build[{i}] is empty')
@@ -1671,7 +1904,13 @@ class PyperfResultsInfo(
                 raise TypeError(f'expected str for build[{i}], got {value!r}')
             # XXX other checks?
 
-    def __new__(cls, uploadid, build=None, filename=None, compared=None):
+    def __new__(
+            cls,
+            uploadid: Optional[PyperfUploadID],
+            build: Optional[List[str]] = None,
+            filename: Optional[str] = None,
+            compared: Optional[_PyperfComparison] = None
+    ):
         return super().__new__(
             cls,
             uploadid=uploadid or None,
@@ -1682,6 +1921,11 @@ class PyperfResultsInfo(
 
     def __init__(self, *args, **kwargs):
         self._validate()
+        self._relfile: Optional[str] = None
+        self._resfile: Optional["PyperfResultsFile"] = None
+        self._resultsroot: Optional[str] = None
+        self._date = Optional[datetime.datetime] = None
+
 
     def _validate(self):
         if not self.uploadid:
@@ -1690,7 +1934,7 @@ class PyperfResultsInfo(
             raise TypeError(self.uploadid)
 
         if self.build:
-            if not isinstance(self.build, tuple):
+            if not isinstance(self.build, list):
                 raise TypeError(self.build)
             else:
                 self._validate_build_items(self.build)
@@ -1702,7 +1946,7 @@ class PyperfResultsInfo(
                 raise ValueError(f'expected an absolute filename, got {self.filename!r}')
 
         if self.compared:
-            if not isinstance(self.compared, PyperfComparison):
+            if not isinstance(self.compared, _PyperfComparison):
                 raise TypeError(self.compared)
 
     def __repr__(self):
@@ -1712,49 +1956,45 @@ class PyperfResultsInfo(
         return f'{prefix}uploadid={str(self.uploadid)!r}, build={remainder})'
 
     @property
-    def resultsroot(self):
-        try:
-            return self._resultsroot
-        except AttributeError:
+    def resultsroot(self) -> Optional[str]:
+        if self._resultsroot is None:
             if not self.filename:
                 return None
-            return os.path.dirname(self.filename)
-            #return None
+            self._resultsroot = os.path.dirname(self.filename)
+        return self._resultsroot
 
     @property
-    def relfile(self):
-        try:
-            return self._relfile
-        except AttributeError:
+    def relfile(self) -> Optional[str]:
+        if self._relfile is None:
             if not self.filename:
                 return None
             if not hasattr(self, '_resultsroot'):
                 return os.path.basename(self.filename)
-            self._relfile = _utils.strinct_relpath(self.filename,
-                                                   self._resultsroot)
-            return self._relfile
+            self._relfile = _utils.strict_relpath(
+                self.filename,
+                self._resultsroot
+            )
+        return self._relfile
 
     @property
-    def resfile(self):
-        try:
-            return self._resfile
-        except AttributeError:
+    def resfile(self) -> Optional["PyperfResultsFile"]:
+        if self._resfile is None:
             if not self.filename:
                 return None
             self._resfile = PyperfResultsFile(self.filename, self.resultsroot)
-            return self._resfile
+        return self._resfile
 
     @property
-    def date(self):
-        try:
-            return self._date
-        except AttributeError:
+    def date(self) -> Optional[datetime.datetime]:
+        if self._date is None:
+            if self.resfile is None:
+                return None
             results = self.resfile.read()
             self._date = results.date
-            return self._date
+        return self._date
 
     @property
-    def baseline(self):
+    def baseline(self) -> Optional[str]:
         if not self.compared:
             return None
         if not self.compared.baseline:
@@ -1762,7 +2002,7 @@ class PyperfResultsInfo(
         return self.compared.baseline.source
 
     @property
-    def mean(self):
+    def mean(self) -> Optional[_utils.ElapsedTimeComparison]:
         if not self.compared:
             return None
         if not self.compared.baseline:
@@ -1770,14 +2010,20 @@ class PyperfResultsInfo(
         return self.compared.mean
 
     @property
-    def isbaseline(self):
+    def isbaseline(self) -> bool:
         return self.compared and not self.compared.baseline
 
     @property
-    def sortkey(self):
+    def sortkey(self) -> Any:
         return (*self.uploadid.sortkey, self.date)
 
-    def match(self, specifier, suites=None, *, checkexists=False):
+    def match(
+            self,
+            specifier: str,
+            suites: Optional[Iterable[SuiteType]] = None,
+            *,
+            checkexists=False
+    ) -> bool:
         # specifier: uploadID, version, filename
         if not specifier:
             return False
@@ -1788,7 +2034,12 @@ class PyperfResultsInfo(
                     return False
         return matched
 
-    def match_uploadid(self, uploadid, *, checkexists=False):
+    def match_uploadid(
+            self,
+            uploadid: Optional[str],
+            *,
+            checkexists=False
+    ) -> bool:
         if not self.uploadid:
             return False
         if not self.uploadid.match(uploadid):
@@ -1798,14 +2049,18 @@ class PyperfResultsInfo(
                 return False
         return True
 
-    def _match(self, specifier, suites):
+    def _match(
+            self,
+            specifier: str,
+            suites: Optional[Iterable[SuiteType]]
+    ) -> bool:
         if self._match_filename(specifier):
             return True
         if self.uploadid and self.uploadid.match(specifier, suites):
             return True
         return False
 
-    def _match_filename(self, filename):
+    def _match_filename(self, filename: str) -> bool:
         if not self.filename:
             return False
         if not isinstance(filename, str):
@@ -1816,24 +2071,29 @@ class PyperfResultsInfo(
         )
         return filename == self.filename
 
-    def find_comparison(self, comparisons):
+    def find_comparison(
+            self,
+            comparisons: PyperfComparisons
+    ) -> Optional[PyperfComparison]:
         try:
             return comparisons.bysource[self.filename]
         except KeyError:
             return None
 
-    def load_results(self):
+    def load_results(self) -> Optional["PyperfResults"]:
         resfile = self.resfile
         if not resfile:
             return None
         return resfile.read()
 
-    def as_rendered_row(self, columns):
-        results = None
+    def as_rendered_row(self, columns: Iterable[str]) -> List[str]:
         row = []
         for column in columns:
             if column == 'date':
-                rendered = self.date.strftime('%Y-%m-%d (%H:%M UTC)')
+                if self.date is None:
+                    rendered = "(unknown)"
+                else:
+                    rendered = self.date.strftime('%Y-%m-%d (%H:%M UTC)')
             elif column == 'release':
                 rendered = f'{self.uploadid.impl} {self.uploadid.version}'
             elif column == 'commit':
@@ -1848,7 +2108,9 @@ class PyperfResultsInfo(
                 rendered = self.baseline or ''
             elif column == 'mean':
                 if self.isbaseline:
-                    rendered = self.BASELINE_REF
+                    # TYPE: BROKEN
+                    # rendered = self.BASELINE_REF
+                    rendered = ''
                 else:
                     rendered = str(self.mean) if self.mean else ''
             else:
@@ -1863,7 +2125,10 @@ class PyperfResultsIndex:
 #    add()
 #    ensure_means()
 
-    def __init__(self, entries=None):
+    def __init__(
+            self,
+            entries: Optional[List[PyperfResultsInfo]] = None
+    ):
         if entries is None:
             entries = []
         self._entries = entries
@@ -1875,7 +2140,11 @@ class PyperfResultsIndex:
     def baseline(self):
         return self.get_baseline()
 
-    def iter_all(self, *, checkexists=False):
+    def iter_all(
+            self,
+            *,
+            checkexists: bool = False
+    ) -> Iterator[PyperfResultsInfo]:
         if checkexists:
             for info in self._entries:
                 if not info.filename or not os.path.isfile(info.filename):
@@ -1884,7 +2153,10 @@ class PyperfResultsIndex:
         else:
             yield from self._entries
 
-    def get_baseline(self, suite=None):
+    def get_baseline(
+            self,
+            suite: Optional[SuiteType] = None
+    ) -> Optional[PyperfResultsInfo]:
         for entry in self._entries:
             if entry.uploadid.suite != suite:
                 continue
@@ -1892,7 +2164,12 @@ class PyperfResultsIndex:
                 return entry
         return None
 
-    def get(self, uploadid, default=None, *, checkexists=False):
+    def get(self,
+            uploadid: Any,
+            default: Optional[PyperfResultsInfo] = None,
+            *,
+            checkexists: bool = False
+    ) -> Optional[PyperfResultsInfo]:
         raw = uploadid
         requested = PyperfUploadID.from_raw(raw)
         if not requested:
@@ -1906,7 +2183,13 @@ class PyperfResultsIndex:
             found = info
         return found
 
-    def match(self, specifier, suites=None, *, checkexists=False):
+    def match(
+            self,
+            specifier: Optional[str],
+            suites: Optional[Iterable[SuiteType]] = None,
+            *,
+            checkexists: bool = False
+    ) -> Iterator[PyperfResultsInfo]:
         # specifier: uploadID, version, filename
         if not specifier:
             return
@@ -1915,8 +2198,13 @@ class PyperfResultsIndex:
                 continue
             yield info
 
-    def match_uploadid(self, uploadid, *, checkexists=True):
-        requested = PyperfUploadID.from_raw(raw)
+    def match_uploadid(
+            self,
+            uploadid: Any,
+            *,
+            checkexists: bool = True
+    ) -> Optional[Iterator[PyperfResultsInfo]]:
+        requested = PyperfUploadID.from_raw(uploadid)
         if not requested:
             return None
         for info in self.iter_all(checkexists=checkexists):
@@ -1924,7 +2212,7 @@ class PyperfResultsIndex:
                 continue
             yield info
 
-    def add(self, info):
+    def add(self, info: PyperfResultsInfo) -> PyperfResultsInfo:
         if not info:
             raise ValueError('missing info')
         elif not isinstance(info, PyperfResultsInfo):
@@ -1932,20 +2220,27 @@ class PyperfResultsIndex:
         self._add(info)
         return info
 
-    def _add(self, info):
+    def _add(self, info: PyperfResultsInfo) -> None:
         #assert info
         # XXX Do not add if already added.
         # XXX Fail if compatid is different but fails are same?
         self._entries.append(info)
 
-    def add_from_results(self, results, compared=None):
+    def add_from_results(
+            self,
+            results: PyperfResults,
+            compared: Optional[_PyperfComparison] = None
+    ) -> PyperfResultsInfo:
         info = PyperfResultsInfo.from_results(results, compared)
         return self.add(info)
 
-    def ensure_means(self, baseline=None):
+    def ensure_means(
+            self,
+            baseline: Optional[Any] = None
+    ) -> List[Tuple[PyperfResultsInfo, PyperfResultsInfo]]:
         requested = _utils.Version.from_raw(baseline).full if baseline else None
 
-        by_suite = {}
+        by_suite: Dict[SuiteType, List[Any]] = {}
         baselines = {}
         entry_indices = {}
         for i, info in enumerate(self._entries):
@@ -1963,7 +2258,11 @@ class PyperfResultsIndex:
         updated = []
         for suite, infos in by_suite.items():
             baseline = baselines[suite]
+            if baseline.resfile is None:
+                raise KeyError
             comparisons = baseline.resfile.compare([i.resfile for i in infos])
+            if comparisons is None:
+                continue
 #            means = comparisons.table.mean_row.others
             for info in infos:
                 compared = info.find_comparison(comparisons)
@@ -1978,11 +2277,14 @@ class PyperfResultsIndex:
                 updated.append((info, copied))
         return updated
 
-    def as_rendered_rows(self, columns):
+    def as_rendered_rows(
+            self,
+            columns: Iterable[str]
+    ) -> Iterator[Tuple[List[str], PyperfResultsInfo]]:
         for info in self._entries:
             yield info.as_rendered_row(columns), info
 
-    def summarized(self):
+    def summarized(self) -> "PyperfResultsIndex":
         """
         Returns a table with only the latest result from a given
         suite/major.minor version.
@@ -2003,7 +2305,10 @@ class PyperfResultsIndex:
 ##################################
 # results files
 
-def normalize_results_filename(filename, resultsroot=None):
+def normalize_results_filename(
+        filename: str,
+        resultsroot: Optional[str] = None
+) -> Tuple[str, str, str]:
     if not filename:
         raise ValueError('missing filename')
     if resultsroot and not os.path.isabs(resultsroot):
@@ -2030,7 +2335,7 @@ class PyperfResultsFile:
     _SUFFIXES = (SUFFIX, COMPRESSED_SUFFIX)
 
     @classmethod
-    def from_raw(cls, raw):
+    def from_raw(cls, raw: Any) -> Optional["PyperfResultsFile"]:
         if not raw:
             return None
         elif isinstance(raw, cls):
@@ -2041,7 +2346,13 @@ class PyperfResultsFile:
             raise TypeError(raw)
 
     @classmethod
-    def from_uploadid(cls, uploadid, resultsroot=None, *, compressed=False):
+    def from_uploadid(
+            cls,
+            uploadid: Any,
+            resultsroot: Optional[str] = None,
+            *,
+            compressed: bool = False
+    ) -> "PyperfResultsFile":
         uploadid = PyperfUploadID.from_raw(uploadid, fail=True)
         return cls(f'{uploadid}{cls.SUFFIX}', resultsroot,
                    compressed=compressed)
@@ -2057,14 +2368,23 @@ class PyperfResultsFile:
     #        return filename, None
 
     @classmethod
-    def _resolve_filename(cls, filename, resultsroot, compressed):
+    def _resolve_filename(
+            cls,
+            filename: str,
+            resultsroot: Optional[str],
+            compressed: bool
+    ) -> Tuple[str, str, str]:
         if not filename:
             raise ValueError('missing filename')
         filename = cls._ensure_suffix(filename, compressed)
         return normalize_results_filename(filename, resultsroot)
 
     @classmethod
-    def _ensure_suffix(cls, filename, compressed):
+    def _ensure_suffix(
+            cls,
+            filename: str,
+            compressed: bool
+    ) -> str:
         if not filename.endswith((cls.SUFFIX, cls.COMPRESSED_SUFFIX)):
             raise ValueError(f'unsupported file suffix ({filename})')
         elif compressed is None:
@@ -2079,10 +2399,16 @@ class PyperfResultsFile:
             return filename[:-len(old)] + new
 
     @classmethod
-    def _is_compressed(cls, filename):
+    def _is_compressed(cls, filename: str) -> bool:
         return filename.endswith(cls.COMPRESSED_SUFFIX)
 
-    def __init__(self, filename, resultsroot=None, *, compressed=None):
+    def __init__(
+            self,
+            filename: str,
+            resultsroot: Optional[str] = None,
+            *,
+            compressed: bool = False
+    ):
         (filename, relfile, resultsroot,
          ) = self._resolve_filename(filename, resultsroot, compressed)
         if os.path.isdir(filename):
@@ -2102,46 +2428,53 @@ class PyperfResultsFile:
         raise NotImplementedError
 
     @property
-    def filename(self):
+    def filename(self) -> str:
         return self._filename
 
     @property
-    def relfile(self):
+    def relfile(self) -> str:
         return self._relfile
 
     @property
-    def resultsroot(self):
+    def resultsroot(self) -> Optional[str]:
         return self._resultsroot
 
     @property
-    def uploadid(self):
+    def uploadid(self) -> Optional[PyperfUploadID]:
         return PyperfUploadID.from_filename(self.filename)
 
     @property
-    def iscompressed(self):
+    def iscompressed(self) -> bool:
         return self._is_compressed(self._filename)
 
-    def read(self):
+    def read(self) -> PyperfResults:
         _open = self.COMPRESSOR.open if self.iscompressed else open
-        with _open(self._filename) as infile:
+        with _open(self._filename) as infile:  # type: ignore[operator]
             text = infile.read()
         if not text:
             raise RuntimeError(f'{self.filename} is empty')
         data = json.loads(text)
         return PyperfResults(data, self)
 
-    def write(self, results):
+    def write(self, results: PyperfResults) -> None:
         data = results.data
         _open = self.COMPRESSOR.open if self.iscompressed else open
         if self.iscompressed:
             text = json.dumps(data, indent=2)
-            with _open(self._filename, 'w') as outfile:
+            with _open(self._filename, 'w') as outfile:  # type: ignore[operator]
                 outfile.write(text.encode('utf-8'))
         else:
-            with _open(self._filename, 'w') as outfile:
+            with _open(self._filename, 'w') as outfile:  # type: ignore[operator]
                 json.dump(data, outfile, indent=2)
 
-    def copy_to(self, filename, resultsroot=None, *, compressed=None):
+    def copy_to(
+            self,
+            filename: str,
+            resultsroot: Optional[str] = None,
+            *,
+            compressed: bool = False
+    ) -> "PyperfResultsFile":
+        copied: PyperfResultsFile
         if isinstance(filename, PyperfResultsFile):
             copied = filename
             if (copied._resultsroot and resultsroot and
@@ -2176,7 +2509,10 @@ class PyperfResultsFile:
             copied.write(results)
         return copied
 
-    def compare(self, others):
+    def compare(
+            self,
+            others: Sequence["PyperfResultsFile"]
+    ) -> Optional[PyperfComparisons]:
         optional = []
         if len(others) == 1:
             optional.append('--group-by-speed')
@@ -2215,7 +2551,10 @@ class PyperfResultsDir:
     ]
 
     @classmethod
-    def _convert_to_uploadid(cls, uploadid):
+    def _convert_to_uploadid(
+            cls,
+            uploadid: Optional[Any] = None
+    ) -> Optional[PyperfUploadID]:
         if not uploadid:
             return None
         orig = uploadid
@@ -2229,7 +2568,7 @@ class PyperfResultsDir:
             return None
         return uploadid
 
-    def __init__(self, root):
+    def __init__(self, root: str):
         _utils.check_str(root, 'root', required=True, fail=True)
         if not os.path.isabs(root):
             raise ValueError(root)
@@ -2243,34 +2582,42 @@ class PyperfResultsDir:
         raise NotImplementedError
 
     @property
-    def root(self):
+    def root(self) -> str:
         return self._root
 
     @property
-    def indexfile(self):
+    def indexfile(self) -> str:
         return self._indexfile
 
-    def _info_from_values(self, relfile, uploadid, build=None,
-                          baseline=None, mean=None, *,
-                          baselines=None):
+    def _info_from_values(
+            self,
+            relfile: str,
+            uploadid: PyperfUploadID,
+            build: Optional[Union[str, List[str]]] = None,
+            baseline: Optional[str] = None,
+            mean: Optional[str] = None,
+            *,
+            baselines: Optional[MutableMapping[str, PyperfComparisonBaseline]] = None
+    ) -> PyperfResultsInfo:
         assert not os.path.isabs(relfile), relfile
         filename = os.path.join(self._root, relfile)
         if not build:
             build = ['PGO', 'LTO']
 #            # XXX Get it from somewhere.
 #            raise NotImplementedError
+        baseline_obj: PyperfComparisonBaseline
         if baseline:
             assert not os.path.isabs(baseline), baseline
             baseline = os.path.join(self._root, baseline)
             if baselines is not None:
                 try:
-                    baseline = baselines[baseline]
+                    baseline_obj = baselines[baseline]
                 except KeyError:
-                    baseline = PyperfComparisonBaseline(baseline)
-                    baselines[baseline] = baseline
+                    baseline_obj = PyperfComparisonBaseline(baseline)
+                    baselines[baseline] = baseline_obj
             else:
-                baseline = PyperfComparisonBaseline(baseline)
-            compared = PyperfComparison(baseline, source=filename, mean=mean)
+                baseline_obj = PyperfComparisonBaseline(baseline)
+            compared = PyperfComparison(baseline_obj, source=filename, mean=mean)
         else:
             assert not mean, mean
             compared = None
@@ -2282,7 +2629,10 @@ class PyperfResultsDir:
             self._root,
         )
 
-    def _info_from_file(self, filename):
+    def _info_from_file(
+            self,
+            filename: str
+    ) -> Tuple[PyperfResultsInfo, PyperfResults]:
         compared = None  # XXX
         return PyperfResultsInfo.from_file(filename, self._root, compared)
 
@@ -2293,16 +2643,16 @@ class PyperfResultsDir:
     def _iter_results_files(self):
         raise NotImplementedError
 
-    def iter_from_files(self):
+    def iter_from_files(self) -> Iterator[PyperfResultsInfo]:
         for filename in self._iter_results_files():
             info, _ = self._info_from_file(filename)
             yield info
 
-    def iter_all(self):
+    def iter_all(self) -> Iterator[PyperfResultsInfo]:
         index = self.load_index()
         yield from index.iter_all()
 
-    def index_from_files(self, *, baseline=None):
+    def index_from_files(self, *, baseline=None) -> PyperfResultsIndex:
         index = PyperfResultsIndex()
         rows = self.iter_from_files()
         for info in sorted(rows, key=(lambda r: r.sortkey)):
@@ -2311,11 +2661,13 @@ class PyperfResultsDir:
             index.ensure_means(baseline=baseline)
         return index
 
-    def load_index(self, *,
-                   baseline=None,
-                   createifmissing=True,
-                   saveifupdated=True,
-                   ):
+    def load_index(
+            self,
+            *,
+            baseline=None,
+            createifmissing: bool = True,
+            saveifupdated: bool = True,
+    ) -> PyperfResultsIndex:
         save = False
         try:
             index = self._load_index()
@@ -2332,10 +2684,10 @@ class PyperfResultsDir:
             self.save_index(index)
         return index
 
-    def _load_index(self):
+    def _load_index(self) -> PyperfResultsIndex:
         # We use a basic tab-separated values format.
         rows = []
-        baselines = {}
+        baselines: MutableMapping[str, PyperfComparisonBaseline] = {}
         for row in self._read_rows():
             parsed = self._parse_row(row)
             info = self._info_from_values(*parsed, baselines=baselines)
@@ -2345,7 +2697,7 @@ class PyperfResultsDir:
             index.add(info)
         return index
 
-    def _read_rows(self):
+    def _read_rows(self) -> Iterator[str]:
         with open(self._indexfile) as infile:
             text = infile.read()
         rows = iter(l
@@ -2357,18 +2709,27 @@ class PyperfResultsDir:
         except StopIteration:
             raise NotImplementedError(self._indexfile)
         if headerstr != '\t'.join(self.INDEX_FIELDS):
-            raise ValueError(header)
+            raise ValueError(headerstr)
         # Now read the rows.
         return rows
 
-    def _parse_row(self, row):
-        rowstr = row
+    # TYPE_TODO
+    def _parse_row(
+            self,
+            rowstr: str
+    ) -> Tuple[
+        str,
+        PyperfUploadID,
+        Optional[str],
+        Optional[str],
+        Optional[str]
+    ]:
         row = rowstr.split('\t')
         if len(row) != len(self.INDEX_FIELDS):
             raise ValueError(rowstr)
         relfile, uploadid, build, baseline, mean = row
-        uploadid = PyperfUploadID.parse(uploadid)
-        if not uploadid:
+        uploadid_resolved = PyperfUploadID.parse(uploadid)
+        if not uploadid_resolved:
             raise ValueError(f'bad uploadid in {rowstr}')
         if not relfile:
             raise ValueError(f'missing relative path for {uploadid}')
@@ -2381,9 +2742,15 @@ class PyperfResultsDir:
                 raise ValueError('missing mean')
         elif mean:
             raise ValueError('missing baseline')
-        return relfile, uploadid, build or None, baseline or None, mean or None
+        return (
+            relfile,
+            uploadid_resolved,
+            build or None,
+            baseline or None,
+            mean or None
+        )
 
-    def save_index(self, index):
+    def save_index(self, index: PyperfResultsIndex) -> None:
         # We use a basic tab-separated values format.
         rows = [self.INDEX_FIELDS]
         for info in sorted(index.iter_all(), key=(lambda v: v.sortkey)):
@@ -2391,13 +2758,12 @@ class PyperfResultsDir:
             rows.append(
                 [(row[f] or '') for f in self.INDEX_FIELDS]
             )
-        rows = ('\t'.join(row) for row in rows)
-        text = os.linesep.join(rows)
+        text = os.linesep.join('\t'.join(row) for row in rows)
         with open(self._indexfile, 'w', encoding='utf-8') as outfile:
             outfile.write(text)
             print(file=outfile)  # Add a blank line at the end.
 
-    def _render_as_row(self, info):
+    def _render_as_row(self, info: PyperfResultsInfo) -> Dict[str, Any]:
         if not info.filename:
             raise NotImplementedError(info)
         if info.resultsroot != self._root:
@@ -2412,17 +2778,36 @@ class PyperfResultsDir:
             'geometric mean': str(info.mean) if info.mean else None,
         }
 
-    def get(self, uploadid, default=None, *, checkexists=True):
+    def get(
+            self,
+            uploadid: Any,
+            default: Optional[None] = None,
+            *,
+            checkexists: bool = True
+    ) -> Optional[PyperfResultsInfo]:
         index = self.load_index()
         return index.get(uploadid, default, checkexists=checkexists)
 
-    def match(self, specifier, suites=None, *, checkexists=True):
+    def match(
+            self,
+            specifier: str,
+            suites: Iterable[SuiteType] = None,
+            *,
+            checkexists: bool = True
+    ) -> Iterator[PyperfResultsInfo]:
         index = self.load_index()
         yield from index.match(specifier, suites, checkexists=checkexists)
 
-    def match_uploadid(self, uploadid, *, checkexists=True):
+    def match_uploadid(
+            self,
+            uploadid: Any,
+            *,
+            checkexists: bool = True
+    ) -> Iterator[PyperfResultsInfo]:
         index = self.load_index()
-        yield from index.match_uploadid(uploadid, checkexists=checkexists)
+        results = index.match_uploadid(uploadid, checkexists=checkexists)
+        if results is not None:
+            yield from results
 
 #    def add(self, info, *,
 #            baseline=None,
@@ -2438,11 +2823,14 @@ class PyperfResultsDir:
 #        ...
 #        index.ensure_means(baseline)
 
-    def add_from_results(self, results, *,
-                         baseline=None,
-                         compressed=False,
-                         split=False,
-                         ):
+    def add_from_results(
+            self,
+            results: PyperfResults,
+            *,
+            baseline: Optional[str] = None,
+            compressed: bool = False,
+            split: bool = False,
+    ):
         if not isinstance(results, PyperfResults):
             raise NotImplementedError(results)
 
@@ -2470,7 +2858,7 @@ class PyperfResultsDir:
             logger.info(f'...as {resfile.relfile}...')
             #copied = suite_results.copy_to(resfile, self._root)
             copied.append(
-                suite_results.copy_to(resfile, self._root)
+                suite_results.copy_to(resfile.filename, self._root)
             )
             logger.info('...done adding')
 
@@ -2494,7 +2882,7 @@ class PyperfResultsDir:
 
 class PyperfUploadsDir(PyperfResultsDir):
 
-    def _iter_results_files(self):
+    def _iter_results_files(self) -> Iterator[str]:
         for name in os.listdir(self._root):
             uploadid = PyperfUploadID.parse(name, allowsuffix=True)
             if not uploadid:
@@ -2519,10 +2907,16 @@ class PyperfResultsStorage:
 #    def get(self, uploadid):
 #        raise NotImplementedError
 
-    def match(self, specifier):
+    def match(self, specifier: str):
         raise NotImplementedError
 
-    def add(self, results, *, compressed=False, split=False):
+    def add(
+            self,
+            results: PyperfResults,
+            *,
+            compressed: bool = False,
+            split: bool = False
+    ):
         raise NotImplementedError
 
 
@@ -2531,16 +2925,22 @@ class PyperfResultsRepo(PyperfResultsStorage):
     BRANCH = 'add-benchmark-results'
 
     @classmethod
-    def from_remote(cls, remote, root, datadir=None, baseline=None):
+    def from_remote(
+            cls,
+            remote: Optional[Union[str, _utils.GitHubTarget]],
+            root: Optional[str],
+            datadir: Optional[str] = None,
+            baseline: Optional[str] = None
+    ) -> "PyperfResultsRepo":
         if not root or not _utils.check_str(root):
             root = None
         elif not os.path.isabs(root):
             raise ValueError(root)
         if isinstance(remote, str):
-            remote = _utils.GitHubTarget.resolve(remote, root)
+            remote_resolved = _utils.GitHubTarget.resolve(remote, root)
         elif not isinstance(remote, _utils.GitHubTarget):
             raise TypeError(f'unsupported remote {remote!r}')
-        raw = remote.ensure_local(root)
+        raw = remote_resolved.ensure_local(root)
 #        raw.clean()
 #        raw.switch_branch('main')
         kwargs = {}
@@ -2548,10 +2948,15 @@ class PyperfResultsRepo(PyperfResultsStorage):
             kwargs['datadir'] = datadir
         if baseline:
             kwargs['baseline'] = baseline
-        return cls(raw, remote, **kwargs)
+        return cls(raw, remote_resolved, **kwargs)
 
     @classmethod
-    def from_root(cls, root, datadir=None, baseline=None):
+    def from_root(
+            cls,
+            root: Optional[str],
+            datadir: Optional[str] = None,
+            baseline: Optional[str] = None
+    ) -> "PyperfResultsRepo":
         if not root or not _utils.check_str(root):
             root = None
         elif not os.path.isabs(root):
@@ -2567,7 +2972,13 @@ class PyperfResultsRepo(PyperfResultsStorage):
             kwargs['baseline'] = baseline
         return cls(raw, remote, **kwargs)
 
-    def __init__(self, raw, remote=None, datadir=None, baseline=None):
+    def __init__(
+            self,
+            raw: Any,
+            remote: Optional[_utils.GitHubTarget] = None,
+            datadir: Optional[str] = None,
+            baseline: Optional[str] = None
+    ):
         if not raw:
             raise ValueError('missing raw')
         elif not isinstance(raw, _utils.GitLocalRepo):
@@ -2584,33 +2995,44 @@ class PyperfResultsRepo(PyperfResultsStorage):
         )
 
     @property
-    def root(self):
+    def root(self) -> str:
         return self._raw.root
 
-    def iter_all(self):
+    def iter_all(self) -> Iterator[PyperfUploadID]:
         for info in self._resultsdir.iter_from_files():
             yield info.uploadid
         #yield from self._resultsdir.iter_from_files()
         #yield from self._resultsdir.iter_all()
 
-    def get(self, uploadid, default=None):
+    def get(
+            self,
+            uploadid: PyperfUploadID,
+            default=None
+    ) -> Optional[PyperfResultsFile]:
         info = self._resultsdir.get(uploadid, default)
         return info.resfile if info else None
         #return self._resultsdir.get(uploadid)
 
-    def match(self, specifier, suites=None):
+    def match(
+            self,
+            specifier: str,
+            suites: Optional[Iterable[SuiteType]] = None
+    ) -> Iterator[Optional[PyperfResultsFile]]:
         for info in self._resultsdir.match(specifier, suites):
             yield info.resfile
         #yield from self._resultsdir.match(specifier, suites)
 
-    def add(self, results, *,
-            branch=None,
-            author=None,
-            compressed=False,
-            split=True,
-            clean=True,
-            push=True,
-            ):
+    def add(
+            self,
+            results: PyperfResults,
+            *,
+            branch: Optional[str] = None,
+            author: Optional[str] = None,
+            compressed: bool = False,
+            split: bool = True,
+            clean: bool = True,
+            push: bool = True,
+    ) -> None:
         repo = self._raw.using_author(author)
         if clean:
             repo.refresh()
@@ -2648,7 +3070,11 @@ class PyperfResultsRepo(PyperfResultsStorage):
         if push:
             self._upload(self.datadir or '.')
 
-    def _update_table(self, index, filename):
+    def _update_table(
+            self,
+            index: PyperfResultsIndex,
+            filename: str
+    ) -> str:
         table_lines = self._render_markdown(index)
         MARKDOWN_START = '<!-- START results table -->'
         MARKDOWN_END = '<!-- END results table -->'
@@ -2676,14 +3102,14 @@ class PyperfResultsRepo(PyperfResultsStorage):
             outfile.write(text)
         return filename
 
-    def _render_markdown(self, index):
+    def _render_markdown(self, index: PyperfResultsIndex) -> Iterator[str]:
         def render_row(row):
             row = (f' {v} ' for v in row)
             return f'| {"|".join(row)} |'
         columns = 'date release commit host mean'.split()
 
         rows = index.as_rendered_rows(columns)
-        by_suite = {}
+        by_suite: Dict[SuiteType, List[List[str]]] = {}
         for row, info in sorted(rows, key=(lambda r: r[1].sortkey)):
             suite = info.uploadid.suite
             if suite not in by_suite:
@@ -2697,25 +3123,25 @@ class PyperfResultsRepo(PyperfResultsStorage):
 #                assert not mean, repr(mean)
                 mean = PyperfComparisonValue.BASELINE
             assert '3.10.4' not in release or mean == '(ref)', repr(mean)
-            row = date, release, commit, host, mean
+            row = [date, release, commit, host, mean]
             by_suite[suite].append(row)
 
-        for suite, rows in sorted(by_suite.items()):
+        for suite2, rows2 in sorted(by_suite.items()):
             hidden = not Benchmarks.SUITES[suite].show_results
             yield ''
             if hidden:
                 yield '<!--'
-            yield f'{suite or "???"}:'
+            yield f'{suite2 or "???"}:'
             yield ''
             yield render_row(columns)
             yield render_row(['---'] * len(columns))
-            for row in rows:
+            for row in rows2:
                 yield render_row(row)
             if hidden:
                 yield '-->'
         yield ''
 
-    def _upload(self, reltarget):
+    def _upload(self, reltarget: str) -> None:
         if not self.remote:
             raise Exception('missing remote')
         url = f'{self.remote.url}/tree/main/{reltarget}'
@@ -2734,7 +3160,12 @@ class FasterCPythonResults(PyperfResultsRepo):
     BASELINE = '3.10.4'
 
     @classmethod
-    def from_remote(cls, remote=None, root=None, baseline=None):
+    def from_remote(  # type: ignore[override]
+            cls,
+            remote: Optional[Union[str, _utils.GitHubTarget]] = None,
+            root: Optional[str] = None,
+            baseline: Optional[str] = None
+    ) -> "PyperfResultsRepo":
         if not remote:
             remote = cls.REMOTE
         return super().from_remote(remote, root, baseline=baseline)

--- a/PORTAL/jobs/_pyperformance.py
+++ b/PORTAL/jobs/_pyperformance.py
@@ -1897,7 +1897,7 @@ class PyperfResultsInfo(
     def from_values(
             cls,
             uploadid: Any,
-            build: Optional[Union[str, List[str]]] = None,
+            build: Optional[_utils.ListOrStrType] = None,
             filename: Optional[str] = None,
             compared: Optional[_PyperfComparison] = None,
             resultsroot: Optional[str] = None,
@@ -1936,7 +1936,7 @@ class PyperfResultsInfo(
     @classmethod
     def _normalize_build(
             cls,
-            build: Optional[Union[str, List[str]]]
+            build: Optional[_utils.ListOrStrType]
     ) -> Optional[List[str]]:
         if not build:
             return None
@@ -2646,7 +2646,7 @@ class PyperfResultsDir:
             self,
             relfile: str,
             uploadid: PyperfUploadID,
-            build: Optional[Union[str, List[str]]] = None,
+            build: Optional[_utils.ListOrStrType] = None,
             baseline: Optional[str] = None,
             mean: Optional[str] = None,
             *,

--- a/PORTAL/jobs/_pyperformance.py
+++ b/PORTAL/jobs/_pyperformance.py
@@ -56,7 +56,7 @@ class Benchmarks:
 
     PYPERFORMANCE = 'pyperformance'
     PYSTON = 'pyston'
-    _SUITES = {
+    _SUITES: Dict[str, Dict[str, Any]] = {
         PYPERFORMANCE: {
             'url': 'https://github.com/python/pyperformance',
             'reldir': 'pyperformance/data-files/benchmarks',

--- a/PORTAL/jobs/_pyperformance.py
+++ b/PORTAL/jobs/_pyperformance.py
@@ -2227,7 +2227,8 @@ class PyperfResultsIndex:
                 return entry
         return None
 
-    def get(self,
+    def get(
+            self,
             uploadid: Any,
             default: Optional[PyperfResultsInfo] = None,
             *,

--- a/PORTAL/jobs/_utils.py
+++ b/PORTAL/jobs/_utils.py
@@ -29,6 +29,8 @@ sudo --login --user <username> ssh-import-id gh:<username>
 
 FsAttrsType = List[Union[Tuple[str, str], str]]
 Numeric = Union[int, float, decimal.Decimal]
+SuiteType = Union[None, str, "Sentinel"]
+SuitesType = Any  # This is a recursive iterable of SuiteType
 
 
 USER: str = os.environ.get('USER', '').strip()
@@ -415,7 +417,7 @@ class TableRow:
 
     def __init__(
             self,
-            data: Mapping[str, str],
+            data: Mapping[str, Any],
             render_value: Callable[[str], str]
     ):
         self.data = data

--- a/PORTAL/jobs/_utils.py
+++ b/PORTAL/jobs/_utils.py
@@ -16,7 +16,7 @@ import textwrap
 import time
 import types
 from typing import (
-    Any, Callable, Dict, Iterable, List, Literal, Mapping, Optional, Sequence,
+    Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence,
     TextIO, Tuple, Type, Union
 )
 
@@ -118,7 +118,7 @@ def validate_int(
         value: Any,
         name: Optional[str] = None,
         *,
-        range: Optional[Literal['non-negative', 'positive']] = None,
+        range: Optional[str] = None,
         required: bool = True
 ) -> Optional[int]:
     def fail(value=value, name=name, range=range):
@@ -156,7 +156,7 @@ def normalize_int(
         value: Any,
         name: Optional[str] = None,
         *,
-        range: Optional[Literal['non-negative', 'positive']] = None,
+        range: Optional[str] = None,
         coerce: bool = False,
         required: bool = True,
 ) -> Optional[int]:

--- a/PORTAL/jobs/_utils.py
+++ b/PORTAL/jobs/_utils.py
@@ -4639,7 +4639,8 @@ class Metadata(types.SimpleNamespace):
             fields = [f for f in vars(self) if not f.startswith('_')]
         elif withextra:
             fields.extend((getattr(self, '_extra', None) or {}).keys())
-        # TODO: Unused variable
+        # TODO: "optional" should be used in the loop to be smarter
+        # about how to handle AttributeError
         optional = set(self.OPTIONAL or ())
         data = {}
         for field in fields:

--- a/PORTAL/jobs/_utils.py
+++ b/PORTAL/jobs/_utils.py
@@ -16,8 +16,8 @@ import textwrap
 import time
 import types
 from typing import (
-    Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence,
-    TextIO, Tuple, Type, Union
+    Any, Callable, Iterable, List, Mapping, Optional, Sequence, TextIO, Tuple,
+    Type, Union
 )
 
 

--- a/PORTAL/jobs/_utils.py
+++ b/PORTAL/jobs/_utils.py
@@ -399,7 +399,7 @@ class RenderingRows:
     def render_count(
             self,
             total: Optional[int] = None,
-            label: str ='matched'
+            label: str = 'matched'
     ) -> Iterable[str]:
         if total is None:
             yield f'(total: {total})'
@@ -1814,8 +1814,8 @@ class GitRemotes:
 
     def __init__(self, repo):
         _repo = GitLocalRepo.from_raw(repo)
-        if not repo:
-            raise TypeError(repo)
+        if not _repo:
+            raise TypeError(_repo)
         self._repo = repo
 
     def _git(self, cmd, *args):
@@ -1868,9 +1868,9 @@ class GitBranches:
 
     def __init__(self, repo):
         _repo = GitLocalRepo.from_raw(repo)
-        if not repo:
+        if not _repo:
             raise TypeError(repo)
-        self._repo = repo
+        self._repo = _repo
 
     @property
     def current(self):

--- a/PORTAL/jobs/_utils.py
+++ b/PORTAL/jobs/_utils.py
@@ -27,6 +27,9 @@ sudo --login --user <username> ssh-import-id gh:<username>
 '''
 
 
+ListOrStrType = Union[str, List[str]]
+
+
 USER = os.environ.get('USER', '').strip()
 SUDO_USER = os.environ.get('SUDO_USER', '').strip()
 HOME = os.path.expanduser('~')

--- a/PORTAL/jobs/_utils.py
+++ b/PORTAL/jobs/_utils.py
@@ -27,9 +27,6 @@ sudo --login --user <username> ssh-import-id gh:<username>
 '''
 
 
-FsAttrsType = List[Union[Tuple[str, str], str]]
-
-
 USER = os.environ.get('USER', '').strip()
 SUDO_USER = os.environ.get('SUDO_USER', '').strip()
 HOME = os.path.expanduser('~')
@@ -535,6 +532,7 @@ class ElapsedTimeWithUnits:
          )
         '''
     REGEX = re.compile(f'^{PAT}$', re.VERBOSE)
+    _units: str
 
     @classmethod
     def parse(cls, elapsedstr, *, fail=False):
@@ -636,7 +634,6 @@ class ElapsedTimeWithUnits:
         return self
 
     def __init__(self, *args, **kwargs):
-        self._units: str
         self._elapsed = self._elapsed.normalize()
         self._validate()
 

--- a/PORTAL/jobs/_utils.py
+++ b/PORTAL/jobs/_utils.py
@@ -15,6 +15,10 @@ import sys
 import textwrap
 import time
 import types
+from typing import (
+    Any, Callable, Dict, Iterable, List, Literal, Mapping, Optional, Sequence,
+    TextIO, Tuple, Type, Union
+)
 
 
 '''
@@ -23,11 +27,15 @@ sudo --login --user <username> ssh-import-id gh:<username>
 '''
 
 
-USER = os.environ.get('USER', '').strip()
-SUDO_USER = os.environ.get('SUDO_USER', '').strip()
-HOME = os.path.expanduser('~')
-CWD = os.getcwd()
-PID = os.getpid()
+FsAttrsType = List[Union[Tuple[str, str], str]]
+Numeric = Union[int, float, decimal.Decimal]
+
+
+USER: str = os.environ.get('USER', '').strip()
+SUDO_USER: str = os.environ.get('SUDO_USER', '').strip()
+HOME: str = os.path.expanduser('~')
+CWD: str = os.getcwd()
+PID: int = os.getpid()
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +43,7 @@ logger = logging.getLogger(__name__)
 ##################################
 # string utils
 
-def check_name(name, *, loose=False):
+def check_name(name: str, *, loose: bool = False) -> None:
     if not name:
         raise ValueError(name)
     orig = name
@@ -45,7 +53,13 @@ def check_name(name, *, loose=False):
         raise ValueError(orig)
 
 
-def check_str(valuestr, label=None, *, required=False, fail=False):
+def check_str(
+        valuestr: str,
+        label: Optional[str] = None,
+        *,
+        required: bool = False,
+        fail: bool = False
+) -> bool:
     if not valuestr:
         if required:
             if fail:
@@ -58,26 +72,31 @@ def check_str(valuestr, label=None, *, required=False, fail=False):
     return True
 
 
-def validate_str(value, argname=None, *, required=True):
+def validate_str(
+        value: str,
+        argname: Optional[str] = None,
+        *,
+        required: bool = True
+) -> None:
     validate_arg(value, str, argname, required=required)
 
 
 ##################################
 # int utils
 
-def ensure_int(raw, min=None):
+def ensure_int(raw: Any, min: Optional[int] = None) -> int:
     if isinstance(raw, int):
         value = raw
     elif isinstance(raw, str):
         value = int(raw)
     else:
         raise TypeError(raw)
-    if value < min:
+    if min is not None and value < min:
         raise ValueError(raw)
     return value
 
 
-def coerce_int(value, *, fail=None):
+def coerce_int(value: Any, *, fail: bool = False) -> Optional[int]:
     if isinstance(value, int):
         return value
     elif not value:
@@ -95,7 +114,13 @@ def coerce_int(value, *, fail=None):
     return None
 
 
-def validate_int(value, name=None, *, range=None, required=True):
+def validate_int(
+        value: Any,
+        name: Optional[str] = None,
+        *,
+        range: Optional[Literal['non-negative', 'positive']] = None,
+        required: bool = True
+) -> Optional[int]:
     def fail(value=value, name=name, range=range):
         qualifier = 'an'
         if isinstance(value, int):
@@ -124,13 +149,17 @@ def validate_int(value, name=None, *, range=None, required=True):
         raise ValueError(f'missing {name}' if name else 'missing')
     else:
         fail()
+    return None
 
 
-def normalize_int(value, name=None, *,
-                  range=None,
-                  coerce=False,
-                  required=True,
-                  ):
+def normalize_int(
+        value: Any,
+        name: Optional[str] = None,
+        *,
+        range: Optional[Literal['non-negative', 'positive']] = None,
+        coerce: bool = False,
+        required: bool = True,
+) -> Optional[int]:
     if coerce:
         value = coerce_int(value)
     return validate_int(value, name, range=range, required=required)
@@ -139,7 +168,13 @@ def normalize_int(value, name=None, *,
 ##################################
 # validation utils
 
-def validate_arg(value, expected, argname=None, *, required=True):
+def validate_arg(
+        value: Any,
+        expected: Type,
+        argname: Optional[str] = None,
+        *,
+        required: bool = True
+) -> None:
     if not isinstance(expected, type):
         raise NotImplementedError(expected)
     if not value:
@@ -155,9 +190,10 @@ def validate_arg(value, expected, argname=None, *, required=True):
 # tables
 
 class ColumnSpec(namedtuple('ColumnSpec', 'name title width align')):
+    RawColumnSpec = Union['ColumnSpec', Tuple[str, Optional[str], int, Optional[str]]]
 
     @classmethod
-    def from_raw(cls, raw):
+    def from_raw(cls, raw: 'RawColumnSpec'):
         if isinstance(raw, cls):
             return raw
         else:
@@ -171,8 +207,14 @@ class TableSpec(namedtuple('TableSpec', 'columns header div rowfmt')):
     MARGIN = 1
 
     @classmethod
-    def from_columns(cls, specs, names=None, *, maxwidth=None):
-        columns, names = cls._normalize_columns(specs, names, maxwidth)
+    def from_columns(
+            cls,
+            specs: Iterable[ColumnSpec.RawColumnSpec],
+            names: Optional[Union[str, Iterable[str]]] = None,
+            *,
+            maxwidth: Optional[int] = None
+    ) -> "TableSpec":
+        columns, normalized_names = cls._normalize_columns(specs, names, maxwidth)
         margin = ' ' * cls.MARGIN
 
         header = div = rowfmt = ''
@@ -190,27 +232,37 @@ class TableSpec(namedtuple('TableSpec', 'columns header div rowfmt')):
 
         self = cls(columns, header, div, rowfmt)
         if names:
-            self._colnames = names
+            self._colnames = normalized_names  # type: ignore[has-type]
+        else:
+            self._colnames = None  # type: ignore[has-type]
         return self
 
     @classmethod
-    def _normalize_columns(cls, specs, names, maxwidth):
-        specs = (ColumnSpec.from_raw(s) for s in specs)
+    def _normalize_columns(
+            cls,
+            specs: Iterable[ColumnSpec.RawColumnSpec],
+            names: Optional[Union[str, Iterable[str]]],
+            maxwidth: Optional[int]
+    ) -> Tuple[List[Any], Optional[List[str]]]:
+        spec_objs = (ColumnSpec.from_raw(s) for s in specs)
         if names:
             if isinstance(names, str):
-                names = names.replace(',', ' ').split()
+                names_list = names.replace(',', ' ').split()
             else:
-                names = list(names)
-            specs = {s.name: s for s in specs}
-            columns = [specs[n] for n in names]
+                names_list = list(names)
+            specs_by_name = {s.name: s for s in spec_objs}
+            columns = [specs_by_name[n] for n in names_list]
         else:
             columns = list(specs)
+            names_list = None
 
         if not maxwidth or maxwidth < 0:
             # XXX Use a minimum set of columns to determine minwidth.
             minwidth = 80
-            maxwidth = max(minwidth, get_termwidth())
+            maxwidth_int = max(minwidth, get_termwidth())
             #print(' '*maxwidth + '|')
+        else:
+            maxwidth_int = maxwidth
 
         sep = cls.SEP
         if not sep:
@@ -232,12 +284,12 @@ class TableSpec(namedtuple('TableSpec', 'columns header div rowfmt')):
             if i > 0:
                 size += len(sep)
             size += margin + columns[i].width + margin
-            if size > maxwidth:
+            if size > maxwidth_int:
                 # XXX Maybe drop other columns than just the tail?
                 # XXX Maybe combine some columns?
                 columns[i:] = []
-                if names:
-                    names[i:] = []
+                if names_list is not None:
+                    names_list[i:] = []
                 break
 
         #if termwidth > minwidth + (19 + 3) * 3:
@@ -256,51 +308,67 @@ class TableSpec(namedtuple('TableSpec', 'columns header div rowfmt')):
         #        ('started,created', 'start / (created)', 21, None),
         #    )
 
-        return columns, names
+        return columns, names_list
 
     @property
-    def colnames(self):
+    def colnames(self) -> List[str]:
         try:
-            return self._colnames
+            return self._colnames  # type: ignore[has-type]
         except AttributeError:
             self._colnames = [c.name for c in self.columns]
             return self._colnames
 
-    def render(self, rows, *, numrows=None, total=None):
+    def render(
+            self,
+            rows: Iterable["TableRow"],
+            *,
+            numrows: Optional[int] = None,
+            total: Optional[int] = None
+    ) -> Iterable[str]:
         # We use a default format here.
         header = [self.div, self.header, self.div]
-        rows = self._render_rows(rows)
-        rows = RenderingRows(rows, header, numrows)
+        rendered_rows = self._render_rows(rows)
+        rendering_rows = RenderingRows(rendered_rows, header, numrows)
         yield from header
-        yield from rows
-        yield div
-        yield from rows.render_count(total)
+        yield from rendering_rows
+        yield self.div
+        yield from rendering_rows.render_count(total)
 
-    def render_rows(self, rows, periodic=None, numrows=None):
-        rows = self._render_rows(rows)
-        return RenderingRows(rows, periodic, numrows)
+    def render_rows(
+            self,
+            rows: Iterable["TableRow"],
+            periodic: Optional[Iterable[str]] = None,
+            numrows: Optional[int] = None
+    ) -> "RenderingRows":
+        rendered_rows = self._render_rows(rows)
+        return RenderingRows(rendered_rows, periodic, numrows)
 
-    def _render_rows(self, rows):
+    def _render_rows(self, rows: Iterable["TableRow"]) -> Iterable[str]:
         fmt = self.rowfmt
         for row in rows:
             values = row.render_values(self.colnames)
             yield fmt.format(*values)
 
-    def _render_row(self, row):
+    def _render_row(self, row: "TableRow") -> str:
         values = row.render_values(self.colnames)
         return self.rowfmt.format(*values)
 
 
 class RenderingRows:
 
-    def __init__(self, rows, periodic=None, numrows=None):
+    def __init__(
+            self,
+            rows: Iterable[str],
+            periodic: Optional[Any] = None,
+            numrows: Optional[int] = None
+    ):
         if not periodic:
             periodic = None
         elif isinstance(periodic, str):
             periodic = [periodic]
         if not numrows:
             try:
-                numrows = len(rows)
+                numrows = len(list(rows))
             except TypeError:
                 numrows = None
         self.rows = iter(rows)
@@ -308,7 +376,7 @@ class RenderingRows:
         self.numrows = numrows
 
         self.count = 0
-        self.pending = []
+        self.pending: List[str] = []
 
     def __eq__(self, other):
         raise NotImplementedError
@@ -316,7 +384,7 @@ class RenderingRows:
     def __iter__(self):
         return self
 
-    def __next__(self):
+    def __next__(self) -> str:
         if self.pending:
             return self.pending.pop(0)
         row = next(self.rows)
@@ -329,7 +397,11 @@ class RenderingRows:
                     return self.pending.pop(0)
         return row
 
-    def render_count(self, total=None, label='matched'):
+    def render_count(
+            self,
+            total: Optional[int] = None,
+            label: str ='matched'
+    ) -> Iterable[str]:
         if total is None:
             yield f'(total: {total})'
         elif self.count == total:
@@ -341,7 +413,11 @@ class RenderingRows:
 
 class TableRow:
 
-    def __init__(self, data, render_value):
+    def __init__(
+            self,
+            data: Mapping[str, str],
+            render_value: Callable[[str], str]
+    ):
         self.data = data
         self.render_value = render_value
         self._colnames = list(data)
@@ -352,7 +428,10 @@ class TableRow:
     def __eq__(self, other):
         raise NotImplementedError
 
-    def render_values(self, colnames=None):
+    def render_values(
+            self,
+            colnames: Optional[Iterable[str]] = None
+    ) -> Iterable[str]:
         if not colnames:
             colnames = self._colnames
         for colname in colnames:
@@ -376,13 +455,17 @@ SECOND = datetime.timedelta(seconds=1)
 DAY = datetime.timedelta(days=1)
 
 
-def utcnow():
+def utcnow() -> float:
     if time.tzname[0] == 'UTC':
         return time.time()
     return time.mktime(time.gmtime())
 
 
-def get_utc_datetime(timestamp=None, *, fail=True):
+def get_utc_datetime(
+        timestamp: Optional[Any] = None,
+        *,
+        fail: bool = True
+) -> Tuple[Optional[datetime.datetime], Optional[bool]]:
     tzinfo = datetime.timezone.utc
     if timestamp is None:
         timestamp = int(utcnow())
@@ -508,35 +591,46 @@ class ElapsedTimeWithUnits:
         return self
 
     @classmethod
-    def _convert_to_seconds(cls, elapsed, units):
+    def _convert_to_seconds(
+            cls,
+            elapsed,
+            units: Optional[str]
+    ) -> "ElapsedTimeWithUnits":
         if units == 's':
             return elapsed
         return (elapsed / cls._resolve_units(units)).normalize()
 
     @classmethod
-    def _convert_from_seconds(cls, elapsed, units):
+    def _convert_from_seconds(
+            cls,
+            elapsed,
+            units: str
+    ) -> "ElapsedTimeWithUnits":
         if units == 's':
             return elapsed
         return (elapsed * cls._resolve_units(units)).normalize()
 
     @classmethod
-    def _resolve_units(cls, units):
-        try:
-            return cls._UNITS[units]
-        except KeyError:
+    def _resolve_units(cls, units: Optional[str]) -> int:
+        if units not in cls._UNITS:
             raise ValueError(f'unsupported units {units!r}')
+        return cls._UNITS[units]
 
     @classmethod
-    def _validate_elapsed(cls, elapsed):
+    def _validate_elapsed(cls, elapsed) -> None:
         if elapsed < 0:
             raise ValueError(f'expected non-negative value, got {elapsed}')
 
     @classmethod
-    def _check_for_abnormal(cls, elapsed, units):
+    def _check_for_abnormal(cls, elapsed, units: str) -> None:
         if elapsed < 1 or elapsed >= 1000:
             logger.warn('abnormal elapsed value {elapsed} {units}, consider normalizing')
 
-    def __new__(cls, elapsed, units='s'):
+    def __new__(
+            cls,
+            elapsed,
+            units: str = 's'
+    ) -> "ElapsedTimeWithUnits":
         self = super().__new__(cls)
         self._elapsed = decimal.Decimal(elapsed)
         self._units = units
@@ -544,6 +638,7 @@ class ElapsedTimeWithUnits:
 
     def __init__(self, *args, **kwargs):
         self._elapsed = self._elapsed.normalize()
+        self._units: Optional[str] = None
         self._validate()
 
     def _validate(self):
@@ -703,7 +798,7 @@ class ElapsedTimeComparison:
 ##################################
 # OS utils
 
-def resolve_user(cfg, user=None):
+def resolve_user(cfg: Any, user: Optional[str] = None) -> str:
     if not user:
         user = USER
         if not user or user == 'benchmarking':
@@ -715,7 +810,11 @@ def resolve_user(cfg, user=None):
     return user
 
 
-def parse_bool_env_var(valstr, *, failunknown=False):
+def parse_bool_env_var(
+        valstr: str,
+        *,
+        failunknown: bool = False
+) -> Optional[bool]:
     m = re.match(r'^\s*(?:(1|y(?:es)?|t(?:rue)?)|(0|no?|f(?:alse)?))\s*$',
                  valstr.lower())
     if not m:
@@ -726,17 +825,22 @@ def parse_bool_env_var(valstr, *, failunknown=False):
     return True if yes else False
 
 
-def get_bool_env_var(name, default=None, *, failunknown=False):
+def get_bool_env_var(
+        name: str,
+        default: Optional[bool] = None,
+        *,
+        failunknown: bool = False
+) -> Optional[bool]:
     value = os.environ.get(name)
     if value is None:
         return default
     return parse_bool_env_var(value, failunknown=failunknown)
 
 
-def resolve_os_name():
+def resolve_os_name() -> str:
     if sys.platform == 'win32':
         return 'windows'
-    elif sys.paltform == 'linux':
+    elif sys.platform == 'linux':
         return 'linux'
     elif sys.platform == 'darwin':
         return 'mac'
@@ -744,7 +848,7 @@ def resolve_os_name():
         raise NotImplementedError(sys.platform)
 
 
-def resolve_cpu_arch():
+def resolve_cpu_arch() -> str:
     uname = platform.uname()
     machine = uname.machine.lower()
     if machine in ('amd64', 'x86_64'):
@@ -757,7 +861,7 @@ def resolve_cpu_arch():
         raise NotImplementedError(machine)
 
 
-def get_termwidth(*, nontty=1000, unknown=80):
+def get_termwidth(*, notty: int = 1000, unknown: int = 80) -> int:
     if os.isatty(sys.stdout.fileno()):
         try:
             termsize = os.get_terminal_size()
@@ -769,7 +873,7 @@ def get_termwidth(*, nontty=1000, unknown=80):
         return unknown or 80
 
 
-def is_proc_running(pid):
+def is_proc_running(pid: int) -> bool:
     if pid == PID:
         return True
     try:
@@ -786,7 +890,12 @@ def is_proc_running(pid):
         return True
 
 
-def run_fg(cmd, *args, cwd=None, env=None):
+def run_fg(
+        cmd: str,
+        *args,
+        cwd: Optional[str] = None,
+        env: Optional[Mapping[str, str]] = None
+) -> subprocess.CompletedProcess:
     if not cwd:
         cwd = os.getcwd()
     argv = [cmd, *args]
@@ -803,7 +912,13 @@ def run_fg(cmd, *args, cwd=None, env=None):
     )
 
 
-def run_bg(argv, logfile=None, *, cwd=None, env=None):
+def run_bg(
+        argv: Union[str, Sequence[str]],
+        logfile: Optional[str] = None,
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[Mapping[str, str]] = None
+) -> None:
     if not cwd:
         cwd = os.getcwd()
 
@@ -842,7 +957,12 @@ def run_bg(argv, logfile=None, *, cwd=None, env=None):
 ##################################
 # file utils
 
-def check_shell_str(value, *, required=True, allowspaces=False):
+def check_shell_str(
+        value: Any,
+        *,
+        required: bool = True,
+        allowspaces: bool = False
+) -> Optional[str]:
     validate_str(value, required=required)
     if not value:
         return None
@@ -851,14 +971,23 @@ def check_shell_str(value, *, required=True, allowspaces=False):
     return value
 
 
-def quote_shell_str(value, *, required=True):
+def quote_shell_str(
+        value: Any,
+        *,
+        required: bool = True
+) -> str:
     value = check_shell_str(value, required=required, allowspaces=True)
     if value is not None:
         value = shlex.quote(value)
     return value
 
 
-def get_next_line(lines, notfound=None, *, skipempty=False):
+def get_next_line(
+        lines: Iterable[str],
+        notfound: Optional[str] = None,
+        *,
+        skipempty: bool = False
+) -> Optional[str]:
     for line in lines:
         if not skipempty or line.rstrip():
             return line
@@ -866,7 +995,7 @@ def get_next_line(lines, notfound=None, *, skipempty=False):
         return notfound
 
 
-def strict_relpath(filename, rootdir):
+def strict_relpath(filename: str, rootdir: Optional[str]) -> str:
     relfile = os.path.relpath(filename, rootdir)
     if relfile.startswith('..' + os.path.sep):
         raise ValueError(f'relpath mismatch ({filename!r}, {rootdir!r})')
@@ -2683,8 +2812,8 @@ class Config(types.SimpleNamespace):
     """The base config for the benchmarking machinery."""
 
     # XXX Get FIELDS from the __init__() signature?
-    FIELDS = ()
-    OPTIONAL = ()
+    FIELDS: List[str] = []
+    OPTIONAL: List[str] = []
 
     FILE = 'benchmarking.json'
 
@@ -4301,7 +4430,7 @@ class CPython(PythonImplementation):
         super().__init__('cpython')
 
 
-def resolve_python_implementation(impl):
+def resolve_python_implementation(impl) -> PythonImplementation:
     if isinstance(impl, str):
         if impl == 'cpython':
             return CPython()
@@ -4415,15 +4544,22 @@ class InvalidMetadataError(MetadataError):
 
 class Metadata(types.SimpleNamespace):
 
-    FIELDS = None
-    OPTIONAL = None
+    FIELDS: List[str] = []
+    OPTIONAL: List[str] = []
 
     _extra = None
 
     @classmethod
-    def load(cls, metafile, *, optional=None, fail=True):
+    def load(
+            cls,
+            metafile: Union[str, TextIO],
+            *,
+            optional: Optional[List[str]] = None,
+            fail: bool = True,
+            **kwargs
+    ):
         if optional is None:
-            optional = cls.OPTIONAL or ()
+            optional = cls.OPTIONAL or []
         filename = getattr(metafile, 'name', metafile)
         try:
             data = cls._load_data(metafile)
@@ -4439,9 +4575,14 @@ class Metadata(types.SimpleNamespace):
         return self
 
     @classmethod
-    def from_jsonable(cls, data, *, optional=None):
+    def from_jsonable(
+            cls,
+            data: Any,
+            *,
+            optional: Optional[List[str]] = None
+    ):
         if optional is None:
-            optional = cls.OPTIONAL or ()
+            optional = cls.OPTIONAL or []
         kwargs, extra = cls._extract_kwargs(data, optional, None)
         self = cls(**kwargs)
         if extra:
@@ -4449,7 +4590,11 @@ class Metadata(types.SimpleNamespace):
         return self
 
     @classmethod
-    def _load_data(cls, metafile, fail=False):
+    def _load_data(
+            cls,
+            metafile: Union[str, TextIO],
+            fail: bool = False
+    ) -> Any:
         if isinstance(metafile, str):
             filename = metafile
             with open(filename) as metafile:
@@ -4463,10 +4608,15 @@ class Metadata(types.SimpleNamespace):
             return None
 
     @classmethod
-    def _extract_kwargs(cls, data, optional, filename):
+    def _extract_kwargs(
+            cls,
+            data: dict,
+            optional: List[str],
+            filename
+    ) -> Tuple[dict, Optional[dict]]:
         kwargs = {}
         extra = {}
-        unused = set(cls.FIELDS or ())
+        unused = set(cls.FIELDS or [])
         for field in data:
             if field in unused:
                 kwargs[field] = data[field]
@@ -4479,21 +4629,12 @@ class Metadata(types.SimpleNamespace):
             raise ValueError(f'missing required data (fields: {missing})')
         return (kwargs, extra) if kwargs else (extra, None)
 
-    def refresh(self, resfile):
-        """Reload from the given file."""
-        fresh = self.load(resfile)
-        # This isn't the best way to go, but it's simple.
-        vars(self).clear()
-        self.__init__(**vars(fresh))
-        return fresh
-
-    def as_jsonable(self, *, withextra=False):
+    def as_jsonable(self, *, withextra: bool = False) -> dict:
         fields = self.FIELDS
         if not fields:
             fields = [f for f in vars(self) if not f.startswith('_')]
         elif withextra:
             fields.extend((getattr(self, '_extra', None) or {}).keys())
-        optional = set(self.OPTIONAL or ())
         data = {}
         for field in fields:
             try:
@@ -4506,7 +4647,12 @@ class Metadata(types.SimpleNamespace):
             data[field] = value
         return data
 
-    def save(self, resfile, *, withextra=False):
+    def save(
+            self,
+            resfile: Union[str, TextIO],
+            *,
+            withextra: bool = False
+    ) -> None:
         if isinstance(resfile, str):
             filename = resfile
             with open(filename, 'w') as resfile:

--- a/PORTAL/jobs/_utils.py
+++ b/PORTAL/jobs/_utils.py
@@ -4417,7 +4417,7 @@ class PythonImplementation:
     def name(self):
         return self._name
 
-    def parse_version(self, version, *, requirestr=True):
+    def parse_version(self, version, *, requirestr=True) -> Version:
         try:
             return self.VERSION.parse(version)
         except TypeError:

--- a/PORTAL/jobs/_workers.py
+++ b/PORTAL/jobs/_workers.py
@@ -59,7 +59,7 @@ class WorkerJobsFS(_common.JobsFS):
 class JobWorker:
     """A worker assigned to run a requested job."""
 
-    def __init__(self, worker: "Worker", fs: WorkerJobsFS):
+    def __init__(self, worker: "Worker", fs: WorkerJobFS):
         self._worker = worker
         self._fs = fs
 
@@ -72,7 +72,7 @@ class JobWorker:
         raise NotImplementedError
 
     @property
-    def fs(self) -> WorkerJobsFS:
+    def fs(self) -> WorkerJobFS:
         return self._fs
 
     @property

--- a/PORTAL/jobs/_workers.py
+++ b/PORTAL/jobs/_workers.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional, Type
+from typing import Any, Type
 
 from . import _utils, _common, requests, JobsConfig
 

--- a/PORTAL/jobs/queue.py
+++ b/PORTAL/jobs/queue.py
@@ -236,6 +236,7 @@ class JobQueue:
         except _utils.InvalidPIDFileError as exc:
             locked = (exc.text, None)
         else:
+            assert pid is not None
             locked = (pid, bool(pid))
         return JobQueueSnapshot(
             datafile=self._datafile,

--- a/PORTAL/jobs/queue.py
+++ b/PORTAL/jobs/queue.py
@@ -134,7 +134,10 @@ class JobQueue:
         return cls.from_fstree(jobsfs)
 
     @classmethod
-    def from_fstree(cls, fs: _common.JobsFS) -> "JobQueue":
+    def from_fstree(
+            cls,
+            fs: Union[str, JobQueueFS, _common.JobsFS]
+    ) -> "JobQueue":
         queuefs: _utils.FSTree
         if isinstance(fs, str):
             queuefs = JobQueueFS(fs)
@@ -142,8 +145,6 @@ class JobQueue:
             queuefs = fs
         elif isinstance(fs, _common.JobsFS):
             queuefs = JobQueueFS(fs.requests)
-        elif hasattr(fs, 'queue') and isinstance(fs.queue, JobQueueFS):
-            queuefs = fs.queue
         else:
             raise TypeError(f'expected JobQueueFS, got {fs!r}')
         self = cls(

--- a/PORTAL/jobs/queue.py
+++ b/PORTAL/jobs/queue.py
@@ -65,7 +65,10 @@ class JobAlreadyQueuedError(QueuedJobError):
 class JobQueueFS(_utils.FSTree):
     """The file structure of the job queue data."""
 
-    def __init__(self, datadir: Union[str, _utils.FSTree]):
+    def __init__(
+            self,
+            datadir: Union[str, _utils.FSTree]  # _common.JobsFS.requests
+    ):
         super().__init__(str(datadir))
         self.data = f'{self.root}/queue.json'
         self.lock = f'{self.root}/queue.lock'

--- a/PORTAL/jobs/requests.py
+++ b/PORTAL/jobs/requests.py
@@ -237,6 +237,10 @@ class Result(_utils.Metadata):
     ])
     CLOSED = 'closed'
 
+    _request: Request
+    _fs: _common.JobFS
+    _get_request: Callable[[str, str], Request]
+
     @classmethod
     def resolve_status(cls, status: str) -> str:
         try:
@@ -347,10 +351,6 @@ class Result(_utils.Metadata):
             history=history,
         )
 
-        self._request: Optional[Request] = None
-        self._get_request: Optional[Callable[(str, str), Request]] = None
-        self._fs = Optional[_common.JobFS] = None
-
     def __str__(self):
         return str(self.reqid)
 
@@ -362,16 +362,19 @@ class Result(_utils.Metadata):
 
     @property
     def request(self) -> Request:
-        if self._request is None:
+        try:
+            return self._request
+        except AttributeError:
             get_request = getattr(self, '_get_request', Request)
             self._request = get_request(self.reqid, self.reqdir)
-        return self._request
+            return self._request
 
     @property
     def fs(self) -> _common.JobFS:
-        if self._fs is None:
+        try:
+            return self._fs
+        except AttributeError:
             raise NotImplementedError
-        return self._fs
 
     @property
     def host(self) -> str:


### PR DESCRIPTION
I know this PR is quite large -- given that it checks out, there's probably not a need for the magnifying glass.  Some of the typing syntax is a little vintage, trying to support Python >= 3.7.

There were a few small changes to the code itself:

- Where a reassignment of a variable shadows the older type, new variable names were introduced
- The `try: ... except: AttributeError` for lazily computing properties pattern throws off mypy, so those were moved to `None` to indicate missing.
- A few small places where members don't seem to exist were commented out -- I assume these are dead code -- those can hopefully be addressed in the future with some unit tests etc.