### PR TITLE
Fix cyclical imports introduced in #93

### DIFF
--- a/PORTAL/jobs/_job.py
+++ b/PORTAL/jobs/_job.py
@@ -6,11 +6,14 @@ import subprocess
 import sys
 import textwrap
 import time
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional, TYPE_CHECKING
 
 from . import _utils, _common, _workers, _current
 from .requests import RequestID, Request, Result, ToRequestIDType
-from . import JobsConfig
+
+
+if TYPE_CHECKING:
+    from . import JobsConfig
 
 
 logger = logging.getLogger(__name__)
@@ -69,7 +72,7 @@ class Job:
             reqid: ToRequestIDType,
             fs: _common.JobFS,
             worker: _workers.JobWorker,
-            cfg: JobsConfig,
+            cfg: "JobsConfig",
             store: Any = None
     ):
         if not fs:
@@ -115,7 +118,7 @@ class Job:
         return self._worker
 
     @property
-    def cfg(self) -> JobsConfig:
+    def cfg(self) -> "JobsConfig":
         return self._cfg
 
     @property

--- a/PORTAL/jobs/_job_compile_bench.py
+++ b/PORTAL/jobs/_job_compile_bench.py
@@ -2,12 +2,15 @@ import configparser
 import logging
 import os.path
 import textwrap
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, Tuple, Union, TYPE_CHECKING
 
-from . import _job
-from . import _utils, _pyperformance, _common, _workers
+from . import _utils, _pyperformance, _common
 from .requests import Request, RequestID, Result, ToRequestIDType
 from . import requests
+
+
+if TYPE_CHECKING:
+    from . import _job, _workers
 
 
 FAKE_DELAY = 3
@@ -282,7 +285,7 @@ def resolve_compile_bench_request(
 
 def build_pyperformance_manifest(
         req: CompileBenchRequest,
-        bfiles: _workers.WorkerJobsFS,
+        bfiles: "_workers.WorkerJobsFS",
 ) -> str:
     return textwrap.dedent(f'''
         [includes]
@@ -293,7 +296,7 @@ def build_pyperformance_manifest(
 
 def build_pyperformance_config(
         req: CompileBenchRequest,
-        bfiles: _workers.WorkerJobsFS
+        bfiles: "_workers.WorkerJobsFS"
 ) -> configparser.ConfigParser:
     cpython = bfiles.repos.cpython
     bfiles_jobfs = bfiles.resolve_request(req.id)
@@ -327,7 +330,7 @@ def build_pyperformance_config(
 
 def build_compile_script(
         req: CompileBenchRequest,
-        bfiles: _workers.WorkerJobsFS,
+        bfiles: "_workers.WorkerJobsFS",
         fake: Optional[Any] = None
 ) -> str:
     exitcode: Optional[Union[str, int]]
@@ -603,8 +606,8 @@ class CompileBenchKind(_common.JobKind):
     def create(
             self,
             reqid: ToRequestIDType,
-            jobfs: _job.JobFS,
-            workerfs: _workers.WorkerJobsFS,
+            jobfs: "_job.JobFS",
+            workerfs: "_workers.WorkerJobsFS",
             *,
             _fake: Optional[Any] = None,
             **req_kwargs

--- a/PORTAL/jobs/_workers.py
+++ b/PORTAL/jobs/_workers.py
@@ -1,7 +1,11 @@
 import logging
-from typing import Any, Type
+from typing import Any, Type, TYPE_CHECKING
 
-from . import _utils, _common, requests, JobsConfig
+from . import _utils, _common
+
+
+if TYPE_CHECKING:
+    from . import JobsConfig, requests
 
 
 logger = logging.getLogger(__name__)
@@ -119,7 +123,7 @@ class Worker:
 
     def resolve_job(
             self,
-            reqid: requests.ToRequestIDType
+            reqid: "requests.ToRequestIDType"
     ) -> JobWorker:
         fs = self._fs.resolve_request(reqid)
         return JobWorker(self, fs)
@@ -131,7 +135,7 @@ class Workers:
     @classmethod
     def from_config(
             cls,
-            cfg: JobsConfig,
+            cfg: "JobsConfig",
             JobsFS: Type[WorkerJobsFS] = WorkerJobsFS
     ) -> "Workers":
         worker = Worker.from_config(cfg.worker, JobsFS)
@@ -150,6 +154,6 @@ class Workers:
 
     def resolve_job(
             self,
-            reqid: requests.ToRequestIDType
+            reqid: "requests.ToRequestIDType"
     ) -> JobWorker:
         return self._worker.resolve_job(reqid)

--- a/PORTAL/jobs/queue.py
+++ b/PORTAL/jobs/queue.py
@@ -3,12 +3,15 @@ import logging
 import sys
 import types
 from typing import (
-    Iterator, Optional, Sequence, Tuple, Union
+    Iterator, Optional, Sequence, Tuple, Union, TYPE_CHECKING
 )
 
 from . import _utils, _common, _job
-from . import JobsConfig
 from .requests import RequestID
+
+
+if TYPE_CHECKING:
+    from . import JobsConfig
 
 
 logger = logging.getLogger(__name__)
@@ -132,7 +135,7 @@ class JobQueue:
     # XXX Add maxsize.
 
     @classmethod
-    def from_config(cls, cfg: JobsConfig) -> "JobQueue":
+    def from_config(cls, cfg: "JobsConfig") -> "JobQueue":
         jobsfs = _common.JobsFS(cfg.data_dir)
         return cls.from_fstree(jobsfs)
 

--- a/PORTAL/jobs/requests.py
+++ b/PORTAL/jobs/requests.py
@@ -3,10 +3,13 @@ import datetime
 import json
 import re
 import types
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union, TYPE_CHECKING
 
-from . import _common
 from . import _utils
+
+
+if TYPE_CHECKING:
+    from . import _common
 
 
 ToRequestIDType = Union[str, "RequestID"]
@@ -132,7 +135,7 @@ class Request(_utils.Metadata):
             cls,
             reqfile: str,
             *,
-            fs: Optional[_common.JobFS] = None,
+            fs: Optional["_common.JobFS"] = None,
             **kwargs
     ) -> Optional["Request"]:
         self = super().load(reqfile, **kwargs)
@@ -190,7 +193,7 @@ class Request(_utils.Metadata):
         return self.id.date
 
     @property
-    def fs(self) -> _common.JobFS:
+    def fs(self) -> "_common.JobFS":
         try:
             return self._fs
         except AttributeError:
@@ -238,7 +241,7 @@ class Result(_utils.Metadata):
     CLOSED = 'closed'
 
     _request: Request
-    _fs: _common.JobFS
+    _fs: "_common.JobFS"
     _get_request: Callable[[str, str], Request]
 
     @classmethod
@@ -370,7 +373,7 @@ class Result(_utils.Metadata):
             return self._request
 
     @property
-    def fs(self) -> _common.JobFS:
+    def fs(self) -> "_common.JobFS":
         try:
             return self._fs
         except AttributeError:


### PR DESCRIPTION
Missed these because I didn't actually run things :(

I went back through all of the new imports added in #93 and put them behind a `TYPE_CHECKING` flag as [per the usual advice](https://adamj.eu/tech/2021/05/13/python-type-hints-how-to-fix-circular-imports/).

Additionally, these revealed that there were some ambiguous shadowing of `RequestID` in `_common`, so I refactored it to just use `from . import requests` rather than `from .requests import RequestID` etc.