### PR TITLE
Fix invalid escape sequence deprecation warning

### DIFF
--- a/PORTAL/jobs/_pyperformance.py
+++ b/PORTAL/jobs/_pyperformance.py
@@ -3181,7 +3181,7 @@ class PyperfResultsRepo(PyperfResultsStorage):
                 by_suite[suite] = []
             date, release, commit, host, mean = row
             relpath = self._raw.relpath(info.filename)
-            relpath = relpath.replace('\/', '/')
+            relpath = relpath.replace(r'\/', '/')
             date = f'[{date}]({relpath})'
             if not mean:
 #                assert info.isbaseline, repr(info)


### PR DESCRIPTION
```
tools/PORTAL/jobs/_pyperformance.py:3143: DeprecationWarning: invalid escape sequence '\/'
    relpath = relpath.replace('\/', '/')
```