### PR TITLE
Fix typo (Part of fix for #110)

### DIFF
--- a/PORTAL/jobs/_common.py
+++ b/PORTAL/jobs/_common.py
@@ -152,7 +152,7 @@ class JobRequestFS(_utils.FSTree):
 class JobResultFS(_utils.FSTree):
     def __init__(self, root: str):
         super().__init__(root)
-        self.resultroot = os.path.dirname(root)
+        self.resultsroot = os.path.dirname(root)
         self.metadata = f'{self.root}/results.json'
 
 


### PR DESCRIPTION
This was making the `upload` command fail, which is part of the problem with the weekly uploads failing.