### PR TITLE
Fix #91: Display a message about the number of jobs in the queue

### DIFF
--- a/PORTAL/jobs/_job.py
+++ b/PORTAL/jobs/_job.py
@@ -469,7 +469,7 @@ class Job:
             raise JobAlreadyFinishedError(self.reqid)
         elif status not in Result.ACTIVE:
             raise JobNeverStartedError(self.reqid)
-        # Go until it has a PID or it finiishes.
+        # Go until it has a PID or it finishes.
         pid = self.get_pid()
         while pid is None:
             if checkssh and os.path.exists(self._fs.ssh_okay):


### PR DESCRIPTION
Just so the user doesn't wonder if things are "hung".