### PR TITLE
add count of code objects that do not access any of their consts

### DIFF
--- a/scripts/count_opcodes.py
+++ b/scripts/count_opcodes.py
@@ -26,6 +26,7 @@ NITEMS = "__nitems__"  # Number of constants/names
 NFILES = "__nfiles__"  # Number of files
 NLINES = "__nlines__"  # Number of lines
 NCODEOBJS = "__ncodeobjs__"  # Number of code objects
+NCODEOBJS_NOCONST = "__ncodeobjs_noconst__"  # Number of code objects that don't access consts
 NERRORS = "__nerrors__"  # Number of files with errors
 CACHE_SIZE = "__cache_size__" # quickening cache size
 CACHE_WASTED = "__cache_wasted__" # Number of wasted cache entries
@@ -48,6 +49,7 @@ SHOW_ITEMS = [
     (NERRORS, "errors"),
     (NFILES, "files"),
     (NCODEOBJS, "code objects"),
+    (NCODEOBJS_NOCONST, "code objects that do not access any consts"),
     (NLINES, "lines"),
     (NOPCODES, "opcodes"),
     (NPAIRS, "opcode pairs"),
@@ -229,6 +231,10 @@ class Reporter:
         return counter
 
 
+STORE_FAST = opcode.opmap["STORE_FAST"]
+LOAD_CONST = opcode.opmap["LOAD_CONST"]
+KW_NAMES = opcode.opmap["KW_NAMES"]
+
 class ConstantsReporter(Reporter):
 
     def reporting_guts(self, counter, co, bias):
@@ -237,9 +243,15 @@ class ConstantsReporter(Reporter):
             key = f"!{const!r}"
             counter[key] += 1
 
+        uses_consts = False
+        co_code = co.co_code
+        for i in range(0, len(co_code), 2):
+            op = co_code[i]
+            if op in (LOAD_CONST, KW_NAMES):
+                uses_consts = True
+        if not uses_consts:
+            counter[NCODEOBJS_NOCONST] += 1
 
-STORE_FAST = opcode.opmap["STORE_FAST"]
-LOAD_CONST = opcode.opmap["LOAD_CONST"]
 
 class StoreNoneReporter(Reporter):
 


### PR DESCRIPTION
It comes to about 11.5% of the code objects:

```
Total:
75 errors;
9,946 files;
235,684 code objects;
27,137 code objects that do not access any consts;
3,669,436 lines;
1,549,337 constants;
1,477,889 total size of co_consts;
189,286 number of co_consts
```